### PR TITLE
Use HTTPS where possible

### DIFF
--- a/demo/javascript-parser-demo.html
+++ b/demo/javascript-parser-demo.html
@@ -47,7 +47,7 @@ h2 {
       </div>
     </div>
   </div>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
   <script src="js/chiffon.min.js"></script>
   <script>
   $(function() {


### PR DESCRIPTION
This avoids mixed content warnings/errors on https://polygonplanet.github.io/Chiffon/demo/javascript-parser-demo.html.
