### PR TITLE
feat: support ES2019-ES2024 syntax (optional chaining `?.`, nullish coalescing `??`, BigInt, etc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build/Release
 node_modules
 
 tasks
+_local*

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 polygon planet
+Copyright (c) 2015 polygonplanet
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/chiffon.js
+++ b/chiffon.js
@@ -51,7 +51,7 @@
       _Boolean = 'Boolean',
       _Keyword = 'Keyword';
 
-  // ECMA-262 11.3 Line Terminators
+  // ECMA-262, 16th: 12.3 Line Terminators
   var lineTerminator = '\\r\\n\\u2028\\u2029';
   var lineTerminatorSequence = '(?:\\r\\n|[' + lineTerminator + '])';
   var whiteSpace = '(?:(?![' + lineTerminator + '])\\s)+';
@@ -69,7 +69,7 @@
     ')' +
   ')';
 
-  // ECMA-262 11.7 Punctuators
+  // ECMA-262, 16th: 12.8 Punctuators
   // Must be ordered from longest to shortest to ensure correct matching.
   var punctuators = '(?:' +
           '>>>=?|[.]{3}|<<=|===|!==|>>=|[*][*]=' +
@@ -122,7 +122,7 @@
     'var|function|this|new|break|catch|finally|try|default|continue|' +
     'switch|const|export|import|class|extends|debugger|super|enum|' +
 
-    // ECMA-262 11.6.2.2 Future Reserved Words
+    // ECMA-262, 16th: 12.7.2 Keywords and Reserved Words
     // Contextually disallowed as identifiers, in strict mode code:
     // `await` is listed in `regexPrefixKeywords` above because ECMA-262
     // includes it in the ReservedWord production; it is reserved only inside
@@ -200,7 +200,7 @@
       (ignore === _RegularExpression ? '' :
         '|' + regexpLiteral + literalSuffix) +
 
-      // ECMA-262 (16th) Numeric Literal (with BigInt and Numeric Separators)
+      // ECMA-262, 16th: 12.9.3 Numeric Literals (with BigInt and Numeric Separators)
       '|' + '0(?:' + '[xX][0-9a-fA-F](?:_?[0-9a-fA-F]+)*' +
                '|' + '[oO][0-7](?:_?[0-7]+)*' +
                '|' + '[bB][01](?:_?[01]+)*' +
@@ -1105,7 +1105,7 @@
         }
       };
     },
-    // ECMA-262 11.8.3 Numeric Literals
+    // ECMA-262, 16th: 12.9.3 Numeric Literals
     parseNumeric: function(value) {
       if (~value.indexOf('_')) {
         value = value.replace(/_/g, '');
@@ -1137,7 +1137,7 @@
 
       return parseFloat(value);
     },
-    // ECMA-262 11.8.4 String Literals
+    // ECMA-262, 16th: 12.9.4 String Literals
     parseString: function(value) {
       var s = '';
       var i = 1;
@@ -1313,7 +1313,7 @@
       this.expect(end);
       return elems;
     },
-    // ECMA-262 12.2 Primary Expression
+    // ECMA-262, 16th: 13.2 Primary Expression
     parsePrimaryExpression: function() {
       // Detect async function before treating it as a plain Identifier
       // because `async` is a contextual keyword.
@@ -1465,7 +1465,7 @@
 
       return expr;
     },
-    // ECMA-262 12.2.6 Object Initializer
+    // ECMA-262, 16th: 13.2.5 Object Initializer
     parseObjectInitializer: function() {
       var node = this.startNode(_ObjectExpression);
       node.properties = this.parseCommaSeparatedElements('{', '}', [],
@@ -1615,7 +1615,7 @@
 
       this.unexpected();
     },
-    // ECMA-262 12.2.5 Array Initializer
+    // ECMA-262, 16th: 13.2.4 Array Initializer
     parseArrayInitializer: function() {
       var node = this.startNode(_ArrayExpression);
       var elems = [];
@@ -1645,7 +1645,7 @@
       node.elements = elems;
       return this.finishNode(node);
     },
-    // ECMA-262 A.2 Expressions
+    // ECMA-262, 16th: A.2 Expressions
     parseExpression: function(allowIn) {
       var node = this.startNode(_SequenceExpression);
       var expr = this.parseAssignmentExpression(allowIn);
@@ -1881,7 +1881,7 @@
       this.startNodeAt(left, startNode);
       return this.finishNode(left);
     },
-    // ECMA-262 12.6 Exponentiation Operator (ES2016).
+    // ECMA-262, 16th: 13.6 Exponentiation Operator
     // Right-associative; binds tighter than multiplicative.
     parseExponentiationExpression: function() {
       var startNode = this.startNode();
@@ -2122,7 +2122,7 @@
       }
       return false;
     },
-    // ECMA-262 13 ECMAScript Language: Statements and Declarations
+    // ECMA-262, 16th: 14 ECMAScript Language: Statements and Declarations
     parseStatement: function() {
       if (this.isAsyncFunctionAhead()) {
         this.next(); // consume 'async'
@@ -2189,7 +2189,7 @@
       node.body = body;
       return this.finishNode(node);
     },
-    // ECMA-262 13.3.2 Variable Statement
+    // ECMA-262, 16th: 14.3.2 Variable Statement
     parseVariableStatement: function(kind, inFor) {
       var node = this.startNode(_VariableDeclaration);
       var allowIn = !inFor;
@@ -2228,7 +2228,7 @@
       node.init = init;
       return this.finishNode(node);
     },
-    // ECMA-262 14.1 Function Definitions
+    // ECMA-262, 16th: 15.2 Function Definitions
     parseFunctionDeclaration: function(options) {
       return this.parseFunctionDefinition(options || {});
     },
@@ -2330,7 +2330,7 @@
       node.argument = this.parseAssignmentExpression(true);
       return this.finishNode(node);
     },
-    // ECMA-262 13.3.3 Destructuring Binding Patterns
+    // ECMA-262, 16th: 14.3.3 Destructuring Binding Patterns
     parseBindingPattern: function() {
       if (this.isContextualIdentifier()) {
         return this.parseContextualIdentifier();
@@ -2438,7 +2438,7 @@
       node.shorthand = shorthand;
       return this.finishNode(node);
     },
-    // ECMA-262 13 Statements and Declarations
+    // ECMA-262, 16th: 14 Statements and Declarations
     parseIfStatement: function() {
       var node = this.startNode(_IfStatement);
       this.expect('if');
@@ -2758,7 +2758,7 @@
       }
       return this.finishNode(node);
     },
-    // ECMA-262 15.2.2 Imports
+    // ECMA-262, 16th: 16.2.2 Imports
     parseImportDeclaration: function() {
       var node = this.startNode(_ImportDeclaration);
 
@@ -2835,7 +2835,7 @@
       node.local = this.parseIdentifier();
       return this.finishNode(node);
     },
-    // ECMA-262 15.2.3 Exports
+    // ECMA-262, 16th: 16.2.3 Exports
     parseExportDeclaration: function() {
       var node = this.startNode();
       this.expect('export');
@@ -2926,7 +2926,7 @@
       node.local = local;
       return this.finishNode(node);
     },
-    // ECMA-262 14.5 Class Definitions
+    // ECMA-262, 16th: 15.7 Class Definitions
     parseClassDeclaration: function() {
       return this.parseClass();
     },

--- a/chiffon.js
+++ b/chiffon.js
@@ -75,7 +75,9 @@
           '>>>=?|[.]{3}|<<=|===|!==|>>=|[*][*]=' +
     '|' + '[+][+](?=[+])|--(?=-)' +
     '|' + '[=!<>*%+/&|^-]=' +
-    '|' + '&&|[|][|]|[+][+]|--|[*][*]|<<|>>|=>' +
+    '|' + '&&|[|][|]|[+][+]|--|[*][*]|<<|>>|=>|[?][?]' +
+    // ES2020 Optional Chaining `?.` (lookahead is not DecimalDigit)
+    '|' + '[?][.](?![0-9])' +
     '|' + '[-+*/%<>=&|^~!?:;,.()[\\]{}]' +
   ')';
 
@@ -887,6 +889,7 @@
       _BreakStatement = 'BreakStatement',
       _CallExpression = 'CallExpression',
       _CatchClause = 'CatchClause',
+      _ChainExpression = 'ChainExpression',
       _ClassBody = 'ClassBody',
       _ClassDeclaration = 'ClassDeclaration',
       _ClassExpression = 'ClassExpression',
@@ -1835,13 +1838,14 @@
           return 9;
         case '||':
           return 10;
-        default:
-          return 0;
+        case '??':
+          return 11;
       }
+      return 0;
     },
     parseBinaryExpression: function(allowIn, base) {
       if (base == null) {
-        base = 10;
+        base = 11;
       }
 
       var startNode = this.startNode();
@@ -1852,7 +1856,7 @@
       }
       var right, operator, node;
 
-      for (var i = 1; i <= 10; i++) {
+      for (var i = 1; i <= 11; i++) {
         while ((prec = this.getBinaryPrecedence(allowIn)) === i) {
           operator = this.value;
 
@@ -1946,8 +1950,19 @@
         expr = this.parsePrimaryExpression();
       }
 
+      var optionalChain = false;
       for (;;) {
-        if (this.value === '.') {
+        if (this.value === '?.') {
+          optionalChain = true;
+          this.next();
+          if (this.value === '(') {
+            expr = this.parseCallExpression(expr, node, true);
+          } else if (this.value === '[') {
+            expr = this.parseComputedMember(expr, node, true);
+          } else {
+            expr = this.parseNonComputedMember(expr, node, true);
+          }
+        } else if (this.value === '.') {
           expr = this.parseNonComputedMember(expr, node);
         } else if (this.value === '[') {
           expr = this.parseComputedMember(expr, node);
@@ -1960,6 +1975,12 @@
         }
       }
 
+      if (optionalChain) {
+        var chain = { type: _ChainExpression };
+        this.startNodeAt(chain, node);
+        chain.expression = expr;
+        return this.finishNodeAt(chain);
+      }
       return expr;
     },
     parseSuper: function() {
@@ -1981,33 +2002,44 @@
 
       return this.finishNode(node);
     },
-    parseCallExpression: function(expr, startNode) {
+    parseCallExpression: function(expr, startNode, optional) {
       var node = this.startNode(_CallExpression);
       this.startNodeAt(node, startNode);
 
       node.callee = expr;
+      if (optional) {
+        node.optional = true;
+      }
       node.arguments = [];
       this.parseArguments(node);
       return this.finishNode(node);
     },
-    parseComputedMember: function(expr, startNode) {
+    parseComputedMember: function(expr, startNode, optional) {
       var node = this.startNode(_MemberExpression);
       this.startNodeAt(node, startNode);
       this.next();
 
       node.computed = true;
+      if (optional) {
+        node.optional = true;
+      }
       node.object = expr;
       node.property = this.parseExpression(true);
 
       this.expect(']');
       return this.finishNode(node);
     },
-    parseNonComputedMember: function(expr, startNode) {
+    parseNonComputedMember: function(expr, startNode, optional) {
       var node = this.startNode(_MemberExpression);
       this.startNodeAt(node, startNode);
-      this.next();
+      if (!optional) {
+        this.next(); // eat '.'
+      }
 
       node.computed = false;
+      if (optional) {
+        node.optional = true;
+      }
       node.object = expr;
 
       // Same type check as parseObjectPropertyName

--- a/chiffon.js
+++ b/chiffon.js
@@ -91,7 +91,7 @@
             '|' + '[^/' + lineTerminator + '\\\\]' +
             ')+' +
     '/' +
-    '(?:[gimsuy]+\\b|)' +
+    '(?:[dgimsuvy]+\\b|)' +
   ')';
 
   var templateLiteral = '`(?:' +

--- a/chiffon.js
+++ b/chiffon.js
@@ -2632,13 +2632,16 @@
     parseCatchClause: function() {
       var node = this.startNode(_CatchClause);
       this.expect('catch');
-      this.expect('(');
 
-      var param = this.parseBindingPattern();
-      this.expect(')');
+      // ES2019 optional catch binding: `catch {}` with no parameter.
+      var param = null;
+      if (this.value === '(') {
+        this.next();
+        param = this.parseBindingPattern();
+        this.expect(')');
+      }
 
       var body = this.parseBlockStatement();
-
       node.param = param;
       node.body = body;
       return this.finishNode(node);

--- a/chiffon.js
+++ b/chiffon.js
@@ -277,6 +277,7 @@
       var token, value, len, index, lines;
       var lineStart, columnStart, columnEnd, hasLineTerminator;
       var type, regex;
+      var options = this.options;
 
       for (var i = 0; i < matches.length; i++) {
         value = matches[i];
@@ -291,7 +292,7 @@
         regex = null;
         type = this.getTokenType(value);
 
-        if (this.options.loc) {
+        if (options.loc) {
           if (type === _String ||
               (type === _Comment && value.charAt(1) === '*')) {
             lines = value.split(lineTerminatorSequenceRe);
@@ -326,14 +327,14 @@
           continue;
         }
 
-        if (this.options.parse && type === _LineTerminator) {
+        if (options.parse && type === _LineTerminator) {
           hasLineTerminator = true;
           continue;
         }
 
-        if ((type === _Comment && !this.options.comment) ||
-            (type === _WhiteSpace && !this.options.whiteSpace) ||
-            (type === _LineTerminator && !this.options.lineTerminator)) {
+        if ((type === _Comment && !options.comment) ||
+            (type === _WhiteSpace && !options.whiteSpace) ||
+            (type === _LineTerminator && !options.lineTerminator)) {
           continue;
         }
 
@@ -351,10 +352,10 @@
           token.regex = regex;
         }
 
-        if (this.options.range) {
+        if (options.range) {
           token.range = [this.index - len, this.index];
         }
-        if (this.options.loc) {
+        if (options.loc) {
           columnEnd = this.index - this.prevLineIndex;
           this.addLoc(token, lineStart, columnStart, this.line, columnEnd);
         }
@@ -666,8 +667,9 @@
       }
       source = '' + source;
 
+      var options = this.options;
       var re;
-      if (this.options.whiteSpace || this.options.range || this.options.loc) {
+      if (options.whiteSpace || options.range || options.loc) {
         re = tokenizeRe;
       } else {
         re = tokenizeNotWhiteSpaceRe;
@@ -1380,7 +1382,7 @@
       var items = [];
       var restElement = null;
 
-      while (true) {
+      for (;;) {
         if (this.value === '...') {
           restElement = this.parseRestElement();
           break;
@@ -1445,11 +1447,12 @@
       return this.finishNode(node);
     },
     parseObjectDefinition: function() {
+      var value = this.value;
       var node;
 
-      if (this.value === '...') {
+      if (value === '...') {
         node = this.parseSpreadElement();
-      } else if (this.value === 'get' || this.value === 'set') {
+      } else if (value === 'get' || value === 'set') {
         node = this.parseObjectGetterSetter();
       } else {
         node = this.parseObjectProperty();
@@ -2809,12 +2812,12 @@
     parseExportDeclaration: function() {
       var node = this.startNode();
       this.expect('export');
-
-      if (this.value === 'default') {
+      var value = this.value;
+      if (value === 'default') {
         return this.parseExportDefaultDeclaration(node);
       }
 
-      if (this.value === '*') {
+      if (value === '*') {
         return this.parseExportAllDeclaration(node);
       }
 

--- a/chiffon.js
+++ b/chiffon.js
@@ -1397,12 +1397,13 @@
       node.type = _ImportExpression;
       this.expect('(');
       node.source = this.parseAssignmentExpression(true);
+      node.options = null;
 
       // Permissively accept (and ignore) the ES2025 options argument.
       if (this.value === ',') {
         this.next();
         if (this.value !== ')') {
-          this.parseAssignmentExpression(true);
+          node.options = this.parseAssignmentExpression(true);
         }
         if (this.value === ',') {
           this.next();
@@ -2041,9 +2042,7 @@
       this.startNodeAt(node, startNode);
 
       node.callee = expr;
-      if (optional) {
-        node.optional = true;
-      }
+      node.optional = !!optional;
       node.arguments = [];
       this.parseArguments(node);
       return this.finishNode(node);
@@ -2054,9 +2053,7 @@
       this.next();
 
       node.computed = true;
-      if (optional) {
-        node.optional = true;
-      }
+      node.optional = !!optional;
       node.object = expr;
       node.property = this.parseExpression(true);
 
@@ -2071,9 +2068,7 @@
       }
 
       node.computed = false;
-      if (optional) {
-        node.optional = true;
-      }
+      node.optional = !!optional;
       node.object = expr;
 
       // Same type check as parseObjectPropertyName
@@ -2955,6 +2950,8 @@
       if (this.value === 'as') {
         this.next();
         node.exported = this.parseIdentifier(true);
+      } else {
+        node.exported = null;
       }
 
       this.expect('from');

--- a/chiffon.js
+++ b/chiffon.js
@@ -6,7 +6,7 @@
  * @version      2.5.4
  * @date         2016-04-17
  * @link         https://github.com/polygonplanet/Chiffon
- * @copyright    Copyright (c) 2015-2016 polygon planet <polygon.planet.aqua@gmail.com>
+ * @copyright    Copyright (c) 2015-2026 polygonplanet <polygon.planet.aqua@gmail.com>
  * @license      Licensed under the MIT license.
  */
 

--- a/chiffon.js
+++ b/chiffon.js
@@ -185,13 +185,15 @@
         '|' + templateLiteral + literalSuffix) +
 
             // String Literal
+            // ES2019 JSON superset: raw U+2028/U+2029 are allowed inside
+            // string literals, so only \r and \n are excluded here.
       '|' + '"(?:' + '\\\\\\r\\n' +
                '|' + '\\\\[\\s\\S]' +
-               '|' + '[^"' + lineTerminator + '\\\\]' +
+               '|' + '[^"\\r\\n\\\\]' +
                ')*"' +
       '|' + "'(?:" + '\\\\\\r\\n' +
                '|' + '\\\\[\\s\\S]' +
-               '|' + "[^'" + lineTerminator + "\\\\]" +
+               '|' + "[^'\\r\\n\\\\]" +
                ")*'" +
 
             // Regular Expression Literal

--- a/chiffon.js
+++ b/chiffon.js
@@ -911,12 +911,14 @@
       _IfStatement = 'IfStatement',
       _ImportDeclaration = 'ImportDeclaration',
       _ImportDefaultSpecifier = 'ImportDefaultSpecifier',
+      _ImportExpression = 'ImportExpression',
       _ImportNamespaceSpecifier = 'ImportNamespaceSpecifier',
       _ImportSpecifier = 'ImportSpecifier',
       _Literal = 'Literal',
       _LabeledStatement = 'LabeledStatement',
       _LogicalExpression = 'LogicalExpression',
       _MemberExpression = 'MemberExpression',
+      _MetaProperty = 'MetaProperty',
       _MethodDefinition = 'MethodDefinition',
       _NewExpression = 'NewExpression',
       _ObjectExpression = 'ObjectExpression',
@@ -1321,7 +1323,7 @@
       // Detect async function before treating it as a plain Identifier
       // because `async` is a contextual keyword.
       if (this.isAsyncFunctionAhead()) {
-        this.next(); // consume 'async'
+        this.next(); // eat 'async'
         return this.parseFunctionExpression({ async: true });
       }
       if (this.isAsyncArrowAhead()) {
@@ -1348,7 +1350,7 @@
     },
     parseAsyncArrowHead: function() {
       var startNode = this.startNode();
-      this.next(); // consume 'async'
+      this.next(); // eat 'async'
 
       var head;
       if (this.value === '(') {
@@ -1373,9 +1375,41 @@
           return this.parseClassExpression();
         case 'this':
           return this.parseThisExpression();
+        case 'import':
+          // ES2020: dynamic import() and import.meta
+          return this.parseImportExpression();
       }
 
       this.unexpected();
+    },
+    parseImportExpression: function() {
+      var node = this.startNode();
+
+      if (this.lookahead().value === '.') {
+        node.type = _MetaProperty;
+        node.meta = this.parseIdentifier(true);
+        this.expect('.');
+        node.property = this.parseIdentifier(true);
+        return this.finishNode(node);
+      }
+
+      this.expect('import');
+      node.type = _ImportExpression;
+      this.expect('(');
+      node.source = this.parseAssignmentExpression(true);
+
+      // Permissively accept (and ignore) the ES2025 options argument.
+      if (this.value === ',') {
+        this.next();
+        if (this.value !== ')') {
+          this.parseAssignmentExpression(true);
+        }
+        if (this.value === ',') {
+          this.next();
+        }
+      }
+      this.expect(')');
+      return this.finishNode(node);
     },
     parseThisExpression: function() {
       var node = this.startNode(_ThisExpression);
@@ -2157,7 +2191,7 @@
     // ECMA-262, 16th: 14 ECMAScript Language: Statements and Declarations
     parseStatement: function() {
       if (this.isAsyncFunctionAhead()) {
-        this.next(); // consume 'async'
+        this.next(); // eat 'async'
         return this.parseFunctionDeclaration({ async: true });
       }
       switch (this.value) {
@@ -2198,12 +2232,16 @@
         case 'for':
           return this.parseForStatement();
         case 'import':
+          var nextValue = this.lookahead().value;
+          if (nextValue === '(' || nextValue === '.') {
+            // Dynamic import and import.meta are expressions, not statements
+            break;
+          }
           return this.parseImportDeclaration();
         case 'export':
           return this.parseExportDeclaration();
-        default:
-          return this.parseMaybeExpressionStatement();
       }
+      return this.parseMaybeExpressionStatement();
     },
     parseScriptBody: function(body, end) {
       while (this.value !== end) {
@@ -2891,7 +2929,7 @@
         expr = this.parseFunctionDeclaration();
         skipSemicolon = true;
       } else if (this.isAsyncFunctionAhead()) {
-        this.next(); // consume 'async'
+        this.next(); // eat 'async'
         expr = this.parseFunctionDeclaration({ async: true });
         skipSemicolon = true;
       } else {
@@ -2909,8 +2947,14 @@
       node.type = _ExportAllDeclaration;
 
       this.expect('*');
-      this.expect('from');
 
+      // ES2020: `export * as foo from "mod"`
+      if (this.value === 'as') {
+        this.next();
+        node.exported = this.parseIdentifier(true);
+      }
+
+      this.expect('from');
       this.assertType(_String);
       node.source = this.parseLiteral();
       this.expectSemicolon();

--- a/chiffon.js
+++ b/chiffon.js
@@ -72,7 +72,7 @@
   // ECMA-262, 16th: 12.8 Punctuators
   // Must be ordered from longest to shortest to ensure correct matching.
   var punctuators = '(?:' +
-          '>>>=?|[.]{3}|<<=|===|!==|>>=|[*][*]=' +
+          '>>>=?|[.]{3}|<<=|===|!==|>>=|[*][*]=|&&=|[|][|]=|[?][?]=' +
     '|' + '[+][+](?=[+])|--(?=-)' +
     '|' + '[=!<>*%+/&|^-]=' +
     '|' + '&&|[|][|]|[+][+]|--|[*][*]|<<|>>|=>|[?][?]' +
@@ -947,7 +947,7 @@
       _YieldExpression = 'YieldExpression';
 
 
-  var assignOpRe = /^(?:[-+*%\/&|]?=|>>>?=|<<=|\*\*=)$/;
+  var assignOpRe = /^(?:[-+*%\/&|]?=|>>>?=|<<=|\*\*=|&&=|\|\|=|\?\?=)$/;
   var unaryOpRe = /^(?:[-+!~]|\+\+|--|typeof|void|delete)$/;
   var octalDigitRe = /^0[0-7]+$/;
 

--- a/chiffon.js
+++ b/chiffon.js
@@ -36,6 +36,7 @@
   var slice = arrayProto.slice;
   var splice = arrayProto.splice;
   var fromCharCode = String.fromCharCode;
+  var hasBigInt = typeof BigInt === 'function';
 
   var _Comment = 'Comment',
       _WhiteSpace = 'WhiteSpace',
@@ -197,13 +198,16 @@
       (ignore === _RegularExpression ? '' :
         '|' + regexpLiteral + literalSuffix) +
 
-            // Numeric Literal
-      '|' + '0(?:' + '[xX][0-9a-fA-F]+' +
-               '|' + '[oO][0-7]+' +
-               '|' + '[bB][01]+' +
-               ')' +
-      '|' + '(?:\\d+(?:[.]\\d*)?|[.]\\d+)(?:[eE][+-]?\\d+)?' +
-      '|' + '[1-9]\\d*' +
+      // ECMA-262 (16th) Numeric Literal (with BigInt and Numeric Separators)
+      '|' + '0(?:' + '[xX][0-9a-fA-F](?:_?[0-9a-fA-F]+)*' +
+               '|' + '[oO][0-7](?:_?[0-7]+)*' +
+               '|' + '[bB][01](?:_?[01]+)*' +
+               ')n?' + // BigIntLiteralSuffix
+      '|' + '(?:0|[1-9](?:_?\\d+)*)n' +
+      '|' + '(?:' + '\\d(?:_?\\d+)*(?:[.](?:\\d(?:_?\\d+)*)?)?' +
+              '|' + '[.]\\d(?:_?\\d+)*' +
+              ')' + '(?:[eE][+-]?\\d(?:_?\\d+)*)?' +
+      '|' + '[1-9](?:_?\\d+)*' +
       '|' + '0[0-7]+' +
 
             // Operators
@@ -1101,6 +1105,10 @@
     },
     // ECMA-262 11.8.3 Numeric Literals
     parseNumeric: function(value) {
+      if (~value.indexOf('_')) {
+        value = value.replace(/_/g, '');
+      }
+
       var i = 0;
       var c = value.charAt(i++);
       var n;
@@ -1212,11 +1220,25 @@
     parseLiteral: function() {
       var node = this.startNode(_Literal);
       var raw = this.value;
-      var value, regex;
+      var value, regex, bigint;
 
       switch (this.type) {
         case _Numeric:
-          value = this.parseNumeric(raw);
+          // ES2020 BigInt literal
+          if (raw.charAt(raw.length - 1) === 'n') {
+            // Remove the 'n' suffix and numeric separators because the BigInt
+            // cannot parse them (e.g., BigInt('123_456') throws a SyntaxError)
+            bigint = raw.replace(/_|n$/g, '');
+            if (hasBigInt) {
+              // ESTree spec requires `bigint` to be the decimal string
+              value = BigInt(bigint);
+              bigint = value.toString();
+            } else {
+              value = null;
+            }
+          } else {
+            value = this.parseNumeric(raw);
+          }
           break;
         case _String:
           value = this.parseString(raw);
@@ -1245,6 +1267,9 @@
       node.raw = raw;
       if (regex) {
         node.regex = regex;
+      }
+      if (bigint != null) {
+        node.bigint = bigint;
       }
 
       return this.finishNode(node);

--- a/chiffon.js
+++ b/chiffon.js
@@ -145,7 +145,7 @@
   var whiteSpaceRe = new RegExp('^' + whiteSpace);
   var regexPrefixRe = new RegExp('(?:' +
           '(?:^(?:' + regexPrefixKeywords + ')$)' +
-    '|' + '(?:' + '(?![.\\]])' + punctuators + '$)' +
+    '|' + '(?:^' + '(?![.\\]]|[+][+]$|--$)' + punctuators + '$)' +
   ')');
   var regexParenKeywordsRe = new RegExp('^(?:' + regexParenKeywords + ')$');
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "minify",
     "syntax"
   ],
-  "author": "polygon planet <polygon.planet.aqua@gmail.com>",
+  "author": "polygonplanet <polygon.planet.aqua@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/polygonplanet/Chiffon/issues"

--- a/tests/fixtures/test-0024-parse-expected.json
+++ b/tests/fixtures/test-0024-parse-expected.json
@@ -123,6 +123,7 @@
           "generator": false,
           "expression": false
         },
+        "optional": false,
         "arguments": []
       }
     }

--- a/tests/fixtures/test-0025-parse-expected.json
+++ b/tests/fixtures/test-0025-parse-expected.json
@@ -123,6 +123,7 @@
           "generator": false,
           "expression": false
         },
+        "optional": false,
         "arguments": []
       }
     }

--- a/tests/fixtures/test-0026-parse-expected.json
+++ b/tests/fixtures/test-0026-parse-expected.json
@@ -64,6 +64,7 @@
           },
           "type": "MemberExpression",
           "computed": false,
+          "optional": false,
           "object": {
             "range": [
               1,
@@ -159,6 +160,7 @@
             "name": "call"
           }
         },
+        "optional": false,
         "arguments": [
           {
             "range": [

--- a/tests/fixtures/test-0076-parse-expected.json
+++ b/tests/fixtures/test-0076-parse-expected.json
@@ -48,6 +48,7 @@
         },
         "type": "MemberExpression",
         "computed": false,
+        "optional": false,
         "object": {
           "range": [
             0,

--- a/tests/fixtures/test-0077-parse-expected.json
+++ b/tests/fixtures/test-0077-parse-expected.json
@@ -48,6 +48,7 @@
         },
         "type": "MemberExpression",
         "computed": true,
+        "optional": false,
         "object": {
           "range": [
             0,
@@ -65,6 +66,7 @@
           },
           "type": "MemberExpression",
           "computed": true,
+          "optional": false,
           "object": {
             "range": [
               0,
@@ -82,6 +84,7 @@
             },
             "type": "MemberExpression",
             "computed": false,
+            "optional": false,
             "object": {
               "range": [
                 0,
@@ -99,6 +102,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   0,
@@ -116,6 +120,7 @@
                 },
                 "type": "MemberExpression",
                 "computed": false,
+                "optional": false,
                 "object": {
                   "range": [
                     0,

--- a/tests/fixtures/test-0078-parse-expected.json
+++ b/tests/fixtures/test-0078-parse-expected.json
@@ -64,6 +64,7 @@
           },
           "type": "MemberExpression",
           "computed": true,
+          "optional": false,
           "object": {
             "range": [
               0,
@@ -81,6 +82,7 @@
             },
             "type": "MemberExpression",
             "computed": true,
+            "optional": false,
             "object": {
               "range": [
                 0,
@@ -98,6 +100,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   0,
@@ -115,6 +118,7 @@
                 },
                 "type": "MemberExpression",
                 "computed": false,
+                "optional": false,
                 "object": {
                   "range": [
                     0,
@@ -132,6 +136,7 @@
                   },
                   "type": "MemberExpression",
                   "computed": false,
+                  "optional": false,
                   "object": {
                     "range": [
                       0,
@@ -281,6 +286,7 @@
             }
           }
         },
+        "optional": false,
         "arguments": []
       }
     }

--- a/tests/fixtures/test-0085-parse-expected.json
+++ b/tests/fixtures/test-0085-parse-expected.json
@@ -298,6 +298,7 @@
           "generator": false,
           "expression": false
         },
+        "optional": false,
         "arguments": []
       }
     }

--- a/tests/fixtures/test-0086-parse-expected.json
+++ b/tests/fixtures/test-0086-parse-expected.json
@@ -319,6 +319,7 @@
           "generator": false,
           "expression": false
         },
+        "optional": false,
         "arguments": []
       }
     }

--- a/tests/fixtures/test-0089-parse-expected.json
+++ b/tests/fixtures/test-0089-parse-expected.json
@@ -177,6 +177,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   49,
@@ -219,6 +220,7 @@
                 "name": "test"
               }
             },
+            "optional": false,
             "arguments": [
               {
                 "range": [
@@ -329,6 +331,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   77,
@@ -371,6 +374,7 @@
                 "name": "test"
               }
             },
+            "optional": false,
             "arguments": [
               {
                 "range": [
@@ -521,6 +525,7 @@
                 },
                 "type": "MemberExpression",
                 "computed": false,
+                "optional": false,
                 "object": {
                   "range": [
                     155,
@@ -563,6 +568,7 @@
                   "name": "test"
                 }
               },
+              "optional": false,
               "arguments": [
                 {
                   "range": [

--- a/tests/fixtures/test-0093-parse-expected.json
+++ b/tests/fixtures/test-0093-parse-expected.json
@@ -153,6 +153,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   22,

--- a/tests/fixtures/test-0094-parse-expected.json
+++ b/tests/fixtures/test-0094-parse-expected.json
@@ -153,6 +153,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   22,

--- a/tests/fixtures/test-0095-parse-expected.json
+++ b/tests/fixtures/test-0095-parse-expected.json
@@ -155,6 +155,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   18,

--- a/tests/fixtures/test-0119-parse-expected.json
+++ b/tests/fixtures/test-0119-parse-expected.json
@@ -81,6 +81,7 @@
             "type": "Identifier",
             "name": "a"
           },
+          "optional": false,
           "arguments": []
         }
       },

--- a/tests/fixtures/test-0120-parse-expected.json
+++ b/tests/fixtures/test-0120-parse-expected.json
@@ -98,6 +98,7 @@
                 "type": "Identifier",
                 "name": "a"
               },
+              "optional": false,
               "arguments": []
             }
           }

--- a/tests/fixtures/test-0187-parse-expected.json
+++ b/tests/fixtures/test-0187-parse-expected.json
@@ -64,6 +64,7 @@
           },
           "type": "MemberExpression",
           "computed": false,
+          "optional": false,
           "object": {
             "range": [
               0,
@@ -125,6 +126,7 @@
             "name": "charCodeAt"
           }
         },
+        "optional": false,
         "arguments": []
       }
     }

--- a/tests/fixtures/test-0212-parse-expected.json
+++ b/tests/fixtures/test-0212-parse-expected.json
@@ -31,6 +31,7 @@
         }
       },
       "type": "ExportAllDeclaration",
+      "exported": null,
       "source": {
         "range": [
           14,

--- a/tests/fixtures/test-0250-parse-expected.json
+++ b/tests/fixtures/test-0250-parse-expected.json
@@ -203,6 +203,7 @@
                         },
                         "type": "Super"
                       },
+                      "optional": false,
                       "arguments": []
                     }
                   }

--- a/tests/fixtures/test-0275-parse-expected.json
+++ b/tests/fixtures/test-0275-parse-expected.json
@@ -65,6 +65,7 @@
           "type": "Identifier",
           "name": "func"
         },
+        "optional": false,
         "arguments": [
           {
             "range": [

--- a/tests/fixtures/test-0276-parse-expected.json
+++ b/tests/fixtures/test-0276-parse-expected.json
@@ -65,6 +65,7 @@
           "type": "Identifier",
           "name": "func"
         },
+        "optional": false,
         "arguments": [
           {
             "range": [

--- a/tests/fixtures/test-0277-parse-expected.json
+++ b/tests/fixtures/test-0277-parse-expected.json
@@ -65,6 +65,7 @@
           "type": "Identifier",
           "name": "func"
         },
+        "optional": false,
         "arguments": [
           {
             "range": [

--- a/tests/fixtures/test-0285-parse-expected.json
+++ b/tests/fixtures/test-0285-parse-expected.json
@@ -391,6 +391,7 @@
           "type": "Identifier",
           "name": "f"
         },
+        "optional": false,
         "arguments": [
           {
             "range": [

--- a/tests/fixtures/test-0290-parse-expected.json
+++ b/tests/fixtures/test-0290-parse-expected.json
@@ -425,6 +425,7 @@
                       "type": "Identifier",
                       "name": "foo"
                     },
+                    "optional": false,
                     "arguments": []
                   }
                 }

--- a/tests/fixtures/test-0292-parse-expected.json
+++ b/tests/fixtures/test-0292-parse-expected.json
@@ -231,6 +231,7 @@
           "type": "Identifier",
           "name": "async"
         },
+        "optional": false,
         "arguments": []
       }
     },
@@ -267,6 +268,7 @@
         },
         "type": "MemberExpression",
         "computed": false,
+        "optional": false,
         "object": {
           "range": [
             46,

--- a/tests/fixtures/test-0293-parse-expected.json
+++ b/tests/fixtures/test-0293-parse-expected.json
@@ -286,6 +286,7 @@
           "type": "Identifier",
           "name": "f"
         },
+        "optional": false,
         "arguments": [
           {
             "range": [

--- a/tests/fixtures/test-0296-parse-expected.json
+++ b/tests/fixtures/test-0296-parse-expected.json
@@ -749,6 +749,7 @@
                     "type": "Identifier",
                     "name": "f"
                   },
+                  "optional": false,
                   "arguments": []
                 }
               }

--- a/tests/fixtures/test-0303-parse-expected.json
+++ b/tests/fixtures/test-0303-parse-expected.json
@@ -121,6 +121,7 @@
         },
         "type": "MemberExpression",
         "computed": false,
+        "optional": false,
         "object": {
           "range": [
             16,
@@ -192,6 +193,7 @@
         },
         "type": "MemberExpression",
         "computed": false,
+        "optional": false,
         "object": {
           "range": [
             28,
@@ -263,6 +265,7 @@
         },
         "type": "MemberExpression",
         "computed": false,
+        "optional": false,
         "object": {
           "range": [
             39,
@@ -334,6 +337,7 @@
         },
         "type": "MemberExpression",
         "computed": false,
+        "optional": false,
         "object": {
           "range": [
             50,
@@ -405,6 +409,7 @@
         },
         "type": "MemberExpression",
         "computed": false,
+        "optional": false,
         "object": {
           "range": [
             61,
@@ -476,6 +481,7 @@
         },
         "type": "MemberExpression",
         "computed": false,
+        "optional": false,
         "object": {
           "range": [
             71,
@@ -547,6 +553,7 @@
         },
         "type": "MemberExpression",
         "computed": false,
+        "optional": false,
         "object": {
           "range": [
             82,
@@ -635,6 +642,7 @@
           },
           "type": "MemberExpression",
           "computed": false,
+          "optional": false,
           "object": {
             "range": [
               92,

--- a/tests/fixtures/test-0304-parse-expected.json
+++ b/tests/fixtures/test-0304-parse-expected.json
@@ -401,6 +401,7 @@
           "generator": false,
           "expression": false
         },
+        "optional": false,
         "arguments": []
       }
     }

--- a/tests/fixtures/test-0309-parse-expected.json
+++ b/tests/fixtures/test-0309-parse-expected.json
@@ -65,6 +65,7 @@
           "type": "Identifier",
           "name": "tokenize"
         },
+        "optional": false,
         "arguments": [
           {
             "range": [

--- a/tests/fixtures/test-0320-parse-expected.json
+++ b/tests/fixtures/test-0320-parse-expected.json
@@ -48,6 +48,7 @@
         },
         "type": "MemberExpression",
         "computed": true,
+        "optional": false,
         "object": {
           "range": [
             0,

--- a/tests/fixtures/test-0326-parse-expected.json
+++ b/tests/fixtures/test-0326-parse-expected.json
@@ -64,6 +64,7 @@
           },
           "type": "MemberExpression",
           "computed": false,
+          "optional": false,
           "object": {
             "range": [
               4,
@@ -106,6 +107,7 @@
             "name": "test"
           }
         },
+        "optional": false,
         "arguments": [
           {
             "range": [
@@ -176,6 +178,7 @@
                 },
                 "type": "MemberExpression",
                 "computed": false,
+                "optional": false,
                 "object": {
                   "range": [
                     16,
@@ -214,6 +217,7 @@
                   "name": "toString"
                 }
               },
+              "optional": false,
               "arguments": []
             }
           }

--- a/tests/fixtures/test-0329-parse-expected.json
+++ b/tests/fixtures/test-0329-parse-expected.json
@@ -1701,6 +1701,7 @@
           },
           "type": "MemberExpression",
           "computed": false,
+          "optional": false,
           "object": {
             "range": [
               418,

--- a/tests/fixtures/test-0336-parse-expected.json
+++ b/tests/fixtures/test-0336-parse-expected.json
@@ -346,6 +346,7 @@
                     },
                     "type": "MemberExpression",
                     "computed": false,
+                    "optional": false,
                     "object": {
                       "range": [
                         64,
@@ -388,6 +389,7 @@
                       "name": "test"
                     }
                   },
+                  "optional": false,
                   "arguments": [
                     {
                       "range": [
@@ -422,6 +424,7 @@
                         },
                         "type": "MemberExpression",
                         "computed": false,
+                        "optional": false,
                         "object": {
                           "range": [
                             73,
@@ -459,6 +462,7 @@
                           "name": "toString"
                         }
                       },
+                      "optional": false,
                       "arguments": []
                     }
                   ]

--- a/tests/fixtures/test-0337-parse-expected.json
+++ b/tests/fixtures/test-0337-parse-expected.json
@@ -346,6 +346,7 @@
                     },
                     "type": "MemberExpression",
                     "computed": false,
+                    "optional": false,
                     "object": {
                       "range": [
                         80,
@@ -388,6 +389,7 @@
                       "name": "test"
                     }
                   },
+                  "optional": false,
                   "arguments": [
                     {
                       "range": [
@@ -422,6 +424,7 @@
                         },
                         "type": "MemberExpression",
                         "computed": false,
+                        "optional": false,
                         "object": {
                           "range": [
                             89,
@@ -459,6 +462,7 @@
                           "name": "toString"
                         }
                       },
+                      "optional": false,
                       "arguments": []
                     }
                   ]

--- a/tests/fixtures/test-0338-parse-expected.json
+++ b/tests/fixtures/test-0338-parse-expected.json
@@ -232,6 +232,7 @@
                           },
                           "type": "MemberExpression",
                           "computed": false,
+                          "optional": false,
                           "object": {
                             "range": [
                               34,
@@ -275,6 +276,7 @@
                   "generator": false,
                   "expression": false
                 },
+                "optional": false,
                 "arguments": [
                   {
                     "range": [

--- a/tests/fixtures/test-0353-parse-expected.json
+++ b/tests/fixtures/test-0353-parse-expected.json
@@ -499,6 +499,7 @@
               },
               "type": "MemberExpression",
               "computed": true,
+              "optional": false,
               "object": {
                 "range": [
                   57,

--- a/tests/fixtures/test-0366-parse-expected.json
+++ b/tests/fixtures/test-0366-parse-expected.json
@@ -480,6 +480,7 @@
                 },
                 "type": "MemberExpression",
                 "computed": false,
+                "optional": false,
                 "object": {
                   "range": [
                     61,

--- a/tests/fixtures/test-0369-parse-expected.json
+++ b/tests/fixtures/test-0369-parse-expected.json
@@ -100,7 +100,8 @@
               "type": "Literal",
               "value": "mod",
               "raw": "\"mod\""
-            }
+            },
+            "options": null
           }
         }
       ],
@@ -156,7 +157,8 @@
           "type": "Literal",
           "value": "side-effect",
           "raw": "\"side-effect\""
-        }
+        },
+        "options": null
       }
     },
     {
@@ -227,6 +229,7 @@
             },
             "type": "MemberExpression",
             "computed": false,
+            "optional": false,
             "object": {
               "range": [
                 58,
@@ -439,7 +442,8 @@
                   },
                   "type": "Identifier",
                   "name": "name"
-                }
+                },
+                "options": null
               }
             }
           }

--- a/tests/fixtures/test-0370-parse-expected.json
+++ b/tests/fixtures/test-0370-parse-expected.json
@@ -85,6 +85,7 @@
         }
       },
       "type": "ExportAllDeclaration",
+      "exported": null,
       "source": {
         "range": [
           41,

--- a/tests/fixtures/test-0372-parse-expected.json
+++ b/tests/fixtures/test-0372-parse-expected.json
@@ -2044,6 +2044,7 @@
                   },
                   "type": "MemberExpression",
                   "computed": false,
+                  "optional": false,
                   "object": {
                     "range": [
                       791,
@@ -2083,6 +2084,7 @@
                     "name": "toString"
                   }
                 },
+                "optional": false,
                 "arguments": []
               },
               {
@@ -2118,6 +2120,7 @@
                   },
                   "type": "MemberExpression",
                   "computed": false,
+                  "optional": false,
                   "object": {
                     "range": [
                       808,
@@ -2156,6 +2159,7 @@
                     "name": "toString"
                   }
                 },
+                "optional": false,
                 "arguments": []
               },
               {
@@ -2191,6 +2195,7 @@
                   },
                   "type": "MemberExpression",
                   "computed": false,
+                  "optional": false,
                   "object": {
                     "range": [
                       825,
@@ -2229,6 +2234,7 @@
                     "name": "toString"
                   }
                 },
+                "optional": false,
                 "arguments": []
               },
               {
@@ -2264,6 +2270,7 @@
                   },
                   "type": "MemberExpression",
                   "computed": false,
+                  "optional": false,
                   "object": {
                     "range": [
                       843,
@@ -2302,6 +2309,7 @@
                     "name": "toString"
                   }
                 },
+                "optional": false,
                 "arguments": []
               },
               {
@@ -2337,6 +2345,7 @@
                   },
                   "type": "MemberExpression",
                   "computed": false,
+                  "optional": false,
                   "object": {
                     "range": [
                       860,
@@ -2375,6 +2384,7 @@
                     "name": "toString"
                   }
                 },
+                "optional": false,
                 "arguments": []
               }
             ]
@@ -2706,6 +2716,7 @@
             },
             "type": "MemberExpression",
             "computed": true,
+            "optional": false,
             "object": {
               "range": [
                 937,
@@ -2782,6 +2793,7 @@
         },
         "type": "MemberExpression",
         "computed": true,
+        "optional": false,
         "object": {
           "range": [
             954,

--- a/tests/fixtures/test-0377-parse-expected.json
+++ b/tests/fixtures/test-0377-parse-expected.json
@@ -624,6 +624,7 @@
                   },
                   "type": "MemberExpression",
                   "computed": true,
+                  "optional": false,
                   "object": {
                     "range": [
                       70,

--- a/tests/fixtures/test-0378-parse-expected.json
+++ b/tests/fixtures/test-0378-parse-expected.json
@@ -1,0 +1,473 @@
+{
+  "range": [
+    0,
+    134
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 13,
+      "column": 1
+    }
+  },
+  "type": "Program",
+  "body": [
+    {
+      "range": [
+        0,
+        19
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 19
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            4,
+            18
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 4
+            },
+            "end": {
+              "line": 1,
+              "column": 18
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              4,
+              14
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 14
+              }
+            },
+            "type": "Identifier",
+            "name": "errorCount"
+          },
+          "init": {
+            "range": [
+              17,
+              18
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 17
+              },
+              "end": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "type": "Literal",
+            "value": 0,
+            "raw": "0"
+          }
+        }
+      ],
+      "kind": "let"
+    },
+    {
+      "range": [
+        20,
+        72
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 6,
+          "column": 1
+        }
+      },
+      "type": "TryStatement",
+      "block": {
+        "range": [
+          24,
+          46
+        ],
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 4
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "type": "BlockStatement",
+        "body": [
+          {
+            "range": [
+              28,
+              44
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 2
+              },
+              "end": {
+                "line": 3,
+                "column": 18
+              }
+            },
+            "type": "ExpressionStatement",
+            "expression": {
+              "range": [
+                28,
+                43
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 17
+                }
+              },
+              "type": "CallExpression",
+              "callee": {
+                "range": [
+                  28,
+                  41
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 15
+                  }
+                },
+                "type": "Identifier",
+                "name": "undefinedFunc"
+              },
+              "arguments": []
+            }
+          }
+        ]
+      },
+      "handler": {
+        "range": [
+          47,
+          72
+        ],
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 2
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "type": "CatchClause",
+        "param": null,
+        "body": {
+          "range": [
+            53,
+            72
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 8
+            },
+            "end": {
+              "line": 6,
+              "column": 1
+            }
+          },
+          "type": "BlockStatement",
+          "body": [
+            {
+              "range": [
+                57,
+                70
+              ],
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 15
+                }
+              },
+              "type": "ExpressionStatement",
+              "expression": {
+                "range": [
+                  57,
+                  69
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 14
+                  }
+                },
+                "type": "UpdateExpression",
+                "operator": "++",
+                "argument": {
+                  "range": [
+                    57,
+                    67
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 12
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "errorCount"
+                },
+                "prefix": false
+              }
+            }
+          ]
+        }
+      },
+      "finalizer": null
+    },
+    {
+      "range": [
+        74,
+        134
+      ],
+      "loc": {
+        "start": {
+          "line": 8,
+          "column": 0
+        },
+        "end": {
+          "line": 13,
+          "column": 1
+        }
+      },
+      "type": "TryStatement",
+      "block": {
+        "range": [
+          78,
+          102
+        ],
+        "loc": {
+          "start": {
+            "line": 8,
+            "column": 4
+          },
+          "end": {
+            "line": 10,
+            "column": 1
+          }
+        },
+        "type": "BlockStatement",
+        "body": [
+          {
+            "range": [
+              82,
+              100
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 2
+              },
+              "end": {
+                "line": 9,
+                "column": 20
+              }
+            },
+            "type": "ThrowStatement",
+            "argument": {
+              "range": [
+                88,
+                99
+              ],
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 8
+                },
+                "end": {
+                  "line": 9,
+                  "column": 19
+                }
+              },
+              "type": "NewExpression",
+              "callee": {
+                "range": [
+                  92,
+                  97
+                ],
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 17
+                  }
+                },
+                "type": "Identifier",
+                "name": "Error"
+              },
+              "arguments": []
+            }
+          }
+        ]
+      },
+      "handler": {
+        "range": [
+          103,
+          112
+        ],
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 2
+          },
+          "end": {
+            "line": 11,
+            "column": 1
+          }
+        },
+        "type": "CatchClause",
+        "param": null,
+        "body": {
+          "range": [
+            109,
+            112
+          ],
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 8
+            },
+            "end": {
+              "line": 11,
+              "column": 1
+            }
+          },
+          "type": "BlockStatement",
+          "body": []
+        }
+      },
+      "finalizer": {
+        "range": [
+          121,
+          134
+        ],
+        "loc": {
+          "start": {
+            "line": 11,
+            "column": 10
+          },
+          "end": {
+            "line": 13,
+            "column": 1
+          }
+        },
+        "type": "BlockStatement",
+        "body": [
+          {
+            "range": [
+              125,
+              132
+            ],
+            "loc": {
+              "start": {
+                "line": 12,
+                "column": 2
+              },
+              "end": {
+                "line": 12,
+                "column": 9
+              }
+            },
+            "type": "ExpressionStatement",
+            "expression": {
+              "range": [
+                125,
+                131
+              ],
+              "loc": {
+                "start": {
+                  "line": 12,
+                  "column": 2
+                },
+                "end": {
+                  "line": 12,
+                  "column": 8
+                }
+              },
+              "type": "UnaryExpression",
+              "operator": "void",
+              "argument": {
+                "range": [
+                  130,
+                  131
+                ],
+                "loc": {
+                  "start": {
+                    "line": 12,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 12,
+                    "column": 8
+                  }
+                },
+                "type": "Literal",
+                "value": 0,
+                "raw": "0"
+              },
+              "prefix": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/test-0378-parse-expected.json
+++ b/tests/fixtures/test-0378-parse-expected.json
@@ -172,6 +172,7 @@
                 "type": "Identifier",
                 "name": "undefinedFunc"
               },
+              "optional": false,
               "arguments": []
             }
           }

--- a/tests/fixtures/test-0378-tokenize-expected.json
+++ b/tests/fixtures/test-0378-tokenize-expected.json
@@ -1,0 +1,146 @@
+[
+  {
+    "type": "Keyword",
+    "value": "let"
+  },
+  {
+    "type": "Identifier",
+    "value": "errorCount"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "try"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "undefinedFunc"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "errorCount"
+  },
+  {
+    "type": "Punctuator",
+    "value": "++"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "try"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "throw"
+  },
+  {
+    "type": "Keyword",
+    "value": "new"
+  },
+  {
+    "type": "Identifier",
+    "value": "Error"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "finally"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "void"
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  }
+]

--- a/tests/fixtures/test-0378-tokenize-loc-range-expected.json
+++ b/tests/fixtures/test-0378-tokenize-loc-range-expected.json
@@ -1,0 +1,650 @@
+[
+  {
+    "type": "Keyword",
+    "value": "let",
+    "range": [
+      0,
+      3
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "errorCount",
+    "range": [
+      4,
+      14
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 4
+      },
+      "end": {
+        "line": 1,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      15,
+      16
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 15
+      },
+      "end": {
+        "line": 1,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      17,
+      18
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 17
+      },
+      "end": {
+        "line": 1,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      18,
+      19
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 18
+      },
+      "end": {
+        "line": 1,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "try",
+    "range": [
+      20,
+      23
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      24,
+      25
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 4
+      },
+      "end": {
+        "line": 2,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "undefinedFunc",
+    "range": [
+      28,
+      41
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 2
+      },
+      "end": {
+        "line": 3,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      41,
+      42
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 15
+      },
+      "end": {
+        "line": 3,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      42,
+      43
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 16
+      },
+      "end": {
+        "line": 3,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      43,
+      44
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 17
+      },
+      "end": {
+        "line": 3,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      45,
+      46
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      47,
+      52
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 2
+      },
+      "end": {
+        "line": 4,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      53,
+      54
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 8
+      },
+      "end": {
+        "line": 4,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "errorCount",
+    "range": [
+      57,
+      67
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 2
+      },
+      "end": {
+        "line": 5,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "++",
+    "range": [
+      67,
+      69
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 12
+      },
+      "end": {
+        "line": 5,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      69,
+      70
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 14
+      },
+      "end": {
+        "line": 5,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      71,
+      72
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "try",
+    "range": [
+      74,
+      77
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 0
+      },
+      "end": {
+        "line": 8,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      78,
+      79
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 4
+      },
+      "end": {
+        "line": 8,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "throw",
+    "range": [
+      82,
+      87
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 2
+      },
+      "end": {
+        "line": 9,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "new",
+    "range": [
+      88,
+      91
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 8
+      },
+      "end": {
+        "line": 9,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "Error",
+    "range": [
+      92,
+      97
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 12
+      },
+      "end": {
+        "line": 9,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      97,
+      98
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 17
+      },
+      "end": {
+        "line": 9,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      98,
+      99
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 18
+      },
+      "end": {
+        "line": 9,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      99,
+      100
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 19
+      },
+      "end": {
+        "line": 9,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      101,
+      102
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 0
+      },
+      "end": {
+        "line": 10,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      103,
+      108
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 2
+      },
+      "end": {
+        "line": 10,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      109,
+      110
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 8
+      },
+      "end": {
+        "line": 10,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      111,
+      112
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 0
+      },
+      "end": {
+        "line": 11,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "finally",
+    "range": [
+      113,
+      120
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 2
+      },
+      "end": {
+        "line": 11,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      121,
+      122
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 10
+      },
+      "end": {
+        "line": 11,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "void",
+    "range": [
+      125,
+      129
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 2
+      },
+      "end": {
+        "line": 12,
+        "column": 6
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      130,
+      131
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 7
+      },
+      "end": {
+        "line": 12,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      131,
+      132
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 8
+      },
+      "end": {
+        "line": 12,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      133,
+      134
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 0
+      },
+      "end": {
+        "line": 13,
+        "column": 1
+      }
+    }
+  }
+]

--- a/tests/fixtures/test-0378.js
+++ b/tests/fixtures/test-0378.js
@@ -1,0 +1,13 @@
+let errorCount = 0;
+try {
+  undefinedFunc();
+} catch {
+  errorCount++;
+}
+
+try {
+  throw new Error();
+} catch {
+} finally {
+  void 0;
+}

--- a/tests/fixtures/test-0379-parse-expected.json
+++ b/tests/fixtures/test-0379-parse-expected.json
@@ -1,0 +1,434 @@
+{
+  "range": [
+    0,
+    118
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 21
+    }
+  },
+  "type": "Program",
+  "body": [
+    {
+      "range": [
+        0,
+        15
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 15
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            4,
+            14
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 4
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              4,
+              7
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 7
+              }
+            },
+            "type": "Identifier",
+            "name": "err"
+          },
+          "init": {
+            "range": [
+              10,
+              14
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 10
+              },
+              "end": {
+                "line": 1,
+                "column": 14
+              }
+            },
+            "type": "Literal",
+            "value": null,
+            "raw": "null"
+          }
+        }
+      ],
+      "kind": "let"
+    },
+    {
+      "range": [
+        17,
+        77
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 12
+        }
+      },
+      "type": "TryStatement",
+      "block": {
+        "range": [
+          21,
+          41
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 4
+          },
+          "end": {
+            "line": 5,
+            "column": 1
+          }
+        },
+        "type": "BlockStatement",
+        "body": [
+          {
+            "range": [
+              25,
+              39
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 2
+              },
+              "end": {
+                "line": 4,
+                "column": 16
+              }
+            },
+            "type": "ThrowStatement",
+            "argument": {
+              "range": [
+                31,
+                38
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 8
+                },
+                "end": {
+                  "line": 4,
+                  "column": 15
+                }
+              },
+              "type": "Literal",
+              "value": "error",
+              "raw": "'error'"
+            }
+          }
+        ]
+      },
+      "handler": {
+        "range": [
+          42,
+          66
+        ],
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 2
+          },
+          "end": {
+            "line": 7,
+            "column": 1
+          }
+        },
+        "type": "CatchClause",
+        "param": {
+          "range": [
+            49,
+            50
+          ],
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 9
+            },
+            "end": {
+              "line": 5,
+              "column": 10
+            }
+          },
+          "type": "Identifier",
+          "name": "e"
+        },
+        "body": {
+          "range": [
+            52,
+            66
+          ],
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 12
+            },
+            "end": {
+              "line": 7,
+              "column": 1
+            }
+          },
+          "type": "BlockStatement",
+          "body": [
+            {
+              "range": [
+                56,
+                64
+              ],
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 2
+                },
+                "end": {
+                  "line": 6,
+                  "column": 10
+                }
+              },
+              "type": "ExpressionStatement",
+              "expression": {
+                "range": [
+                  56,
+                  63
+                ],
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 9
+                  }
+                },
+                "type": "AssignmentExpression",
+                "operator": "=",
+                "left": {
+                  "range": [
+                    56,
+                    59
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 5
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "err"
+                },
+                "right": {
+                  "range": [
+                    62,
+                    63
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 8
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 9
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "e"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "finalizer": {
+        "range": [
+          75,
+          77
+        ],
+        "loc": {
+          "start": {
+            "line": 7,
+            "column": 10
+          },
+          "end": {
+            "line": 7,
+            "column": 12
+          }
+        },
+        "type": "BlockStatement",
+        "body": []
+      }
+    },
+    {
+      "range": [
+        79,
+        118
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 0
+        },
+        "end": {
+          "line": 11,
+          "column": 21
+        }
+      },
+      "type": "TryStatement",
+      "block": {
+        "range": [
+          83,
+          98
+        ],
+        "loc": {
+          "start": {
+            "line": 9,
+            "column": 4
+          },
+          "end": {
+            "line": 11,
+            "column": 1
+          }
+        },
+        "type": "BlockStatement",
+        "body": [
+          {
+            "range": [
+              87,
+              96
+            ],
+            "loc": {
+              "start": {
+                "line": 10,
+                "column": 2
+              },
+              "end": {
+                "line": 10,
+                "column": 11
+              }
+            },
+            "type": "ThrowStatement",
+            "argument": {
+              "range": [
+                93,
+                95
+              ],
+              "loc": {
+                "start": {
+                  "line": 10,
+                  "column": 8
+                },
+                "end": {
+                  "line": 10,
+                  "column": 10
+                }
+              },
+              "type": "Literal",
+              "value": "",
+              "raw": "''"
+            }
+          }
+        ]
+      },
+      "handler": {
+        "range": [
+          99,
+          107
+        ],
+        "loc": {
+          "start": {
+            "line": 11,
+            "column": 2
+          },
+          "end": {
+            "line": 11,
+            "column": 10
+          }
+        },
+        "type": "CatchClause",
+        "param": null,
+        "body": {
+          "range": [
+            105,
+            107
+          ],
+          "loc": {
+            "start": {
+              "line": 11,
+              "column": 8
+            },
+            "end": {
+              "line": 11,
+              "column": 10
+            }
+          },
+          "type": "BlockStatement",
+          "body": []
+        }
+      },
+      "finalizer": {
+        "range": [
+          116,
+          118
+        ],
+        "loc": {
+          "start": {
+            "line": 11,
+            "column": 19
+          },
+          "end": {
+            "line": 11,
+            "column": 21
+          }
+        },
+        "type": "BlockStatement",
+        "body": []
+      }
+    }
+  ]
+}

--- a/tests/fixtures/test-0379-tokenize-expected.json
+++ b/tests/fixtures/test-0379-tokenize-expected.json
@@ -1,0 +1,146 @@
+[
+  {
+    "type": "Keyword",
+    "value": "let"
+  },
+  {
+    "type": "Identifier",
+    "value": "err"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Null",
+    "value": "null"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "try"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "throw"
+  },
+  {
+    "type": "String",
+    "value": "'error'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "e"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "err"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "e"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "finally"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "try"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "throw"
+  },
+  {
+    "type": "String",
+    "value": "''"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "finally"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  }
+]

--- a/tests/fixtures/test-0379-tokenize-loc-range-expected.json
+++ b/tests/fixtures/test-0379-tokenize-loc-range-expected.json
@@ -1,0 +1,650 @@
+[
+  {
+    "type": "Keyword",
+    "value": "let",
+    "range": [
+      0,
+      3
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "err",
+    "range": [
+      4,
+      7
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 4
+      },
+      "end": {
+        "line": 1,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      8,
+      9
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 8
+      },
+      "end": {
+        "line": 1,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Null",
+    "value": "null",
+    "range": [
+      10,
+      14
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 10
+      },
+      "end": {
+        "line": 1,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      14,
+      15
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 14
+      },
+      "end": {
+        "line": 1,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "try",
+    "range": [
+      17,
+      20
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      21,
+      22
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 4
+      },
+      "end": {
+        "line": 3,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "throw",
+    "range": [
+      25,
+      30
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 2
+      },
+      "end": {
+        "line": 4,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'error'",
+    "range": [
+      31,
+      38
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 8
+      },
+      "end": {
+        "line": 4,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      38,
+      39
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 15
+      },
+      "end": {
+        "line": 4,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      40,
+      41
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      42,
+      47
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 2
+      },
+      "end": {
+        "line": 5,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      48,
+      49
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 8
+      },
+      "end": {
+        "line": 5,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "e",
+    "range": [
+      49,
+      50
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 9
+      },
+      "end": {
+        "line": 5,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      50,
+      51
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 10
+      },
+      "end": {
+        "line": 5,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      52,
+      53
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 12
+      },
+      "end": {
+        "line": 5,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "err",
+    "range": [
+      56,
+      59
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 2
+      },
+      "end": {
+        "line": 6,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      60,
+      61
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 6
+      },
+      "end": {
+        "line": 6,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "e",
+    "range": [
+      62,
+      63
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 8
+      },
+      "end": {
+        "line": 6,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      63,
+      64
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 9
+      },
+      "end": {
+        "line": 6,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      65,
+      66
+    ],
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 0
+      },
+      "end": {
+        "line": 7,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "finally",
+    "range": [
+      67,
+      74
+    ],
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 2
+      },
+      "end": {
+        "line": 7,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      75,
+      76
+    ],
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 10
+      },
+      "end": {
+        "line": 7,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      76,
+      77
+    ],
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 11
+      },
+      "end": {
+        "line": 7,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "try",
+    "range": [
+      79,
+      82
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 0
+      },
+      "end": {
+        "line": 9,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      83,
+      84
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 4
+      },
+      "end": {
+        "line": 9,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "throw",
+    "range": [
+      87,
+      92
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 2
+      },
+      "end": {
+        "line": 10,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "''",
+    "range": [
+      93,
+      95
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 8
+      },
+      "end": {
+        "line": 10,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      95,
+      96
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 10
+      },
+      "end": {
+        "line": 10,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      97,
+      98
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 0
+      },
+      "end": {
+        "line": 11,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      99,
+      104
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 2
+      },
+      "end": {
+        "line": 11,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      105,
+      106
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 8
+      },
+      "end": {
+        "line": 11,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      106,
+      107
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 9
+      },
+      "end": {
+        "line": 11,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "finally",
+    "range": [
+      108,
+      115
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 11
+      },
+      "end": {
+        "line": 11,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      116,
+      117
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 19
+      },
+      "end": {
+        "line": 11,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      117,
+      118
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 20
+      },
+      "end": {
+        "line": 11,
+        "column": 21
+      }
+    }
+  }
+]

--- a/tests/fixtures/test-0379.js
+++ b/tests/fixtures/test-0379.js
@@ -1,0 +1,11 @@
+let err = null;
+
+try {
+  throw 'error';
+} catch (e) {
+  err = e;
+} finally {}
+
+try {
+  throw '';
+} catch {} finally {}

--- a/tests/fixtures/test-0380-parse-expected.json
+++ b/tests/fixtures/test-0380-parse-expected.json
@@ -1,0 +1,1154 @@
+{
+  "range": [
+    0,
+    276
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 18,
+      "column": 1
+    }
+  },
+  "type": "Program",
+  "body": [
+    {
+      "range": [
+        0,
+        18
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            6,
+            17
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 17
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              6,
+              12
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 1,
+                "column": 12
+              }
+            },
+            "type": "Identifier",
+            "name": "errors"
+          },
+          "init": {
+            "range": [
+              15,
+              17
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 15
+              },
+              "end": {
+                "line": 1,
+                "column": 17
+              }
+            },
+            "type": "ArrayExpression",
+            "elements": []
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        19,
+        93
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 6,
+          "column": 1
+        }
+      },
+      "type": "TryStatement",
+      "block": {
+        "range": [
+          23,
+          45
+        ],
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 4
+          },
+          "end": {
+            "line": 4,
+            "column": 1
+          }
+        },
+        "type": "BlockStatement",
+        "body": [
+          {
+            "range": [
+              27,
+              43
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 2
+              },
+              "end": {
+                "line": 3,
+                "column": 18
+              }
+            },
+            "type": "ExpressionStatement",
+            "expression": {
+              "range": [
+                27,
+                42
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 17
+                }
+              },
+              "type": "CallExpression",
+              "callee": {
+                "range": [
+                  27,
+                  40
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 15
+                  }
+                },
+                "type": "Identifier",
+                "name": "undefinedFunc"
+              },
+              "arguments": []
+            }
+          }
+        ]
+      },
+      "handler": {
+        "range": [
+          46,
+          93
+        ],
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 2
+          },
+          "end": {
+            "line": 6,
+            "column": 1
+          }
+        },
+        "type": "CatchClause",
+        "param": {
+          "range": [
+            53,
+            64
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 9
+            },
+            "end": {
+              "line": 4,
+              "column": 20
+            }
+          },
+          "type": "ObjectPattern",
+          "properties": [
+            {
+              "range": [
+                55,
+                62
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 11
+                },
+                "end": {
+                  "line": 4,
+                  "column": 18
+                }
+              },
+              "type": "Property",
+              "key": {
+                "range": [
+                  55,
+                  62
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 18
+                  }
+                },
+                "type": "Identifier",
+                "name": "message"
+              },
+              "computed": false,
+              "value": {
+                "range": [
+                  55,
+                  62
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 18
+                  }
+                },
+                "type": "Identifier",
+                "name": "message"
+              },
+              "kind": "init",
+              "method": false,
+              "shorthand": true
+            }
+          ]
+        },
+        "body": {
+          "range": [
+            66,
+            93
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 22
+            },
+            "end": {
+              "line": 6,
+              "column": 1
+            }
+          },
+          "type": "BlockStatement",
+          "body": [
+            {
+              "range": [
+                70,
+                91
+              ],
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 2
+                },
+                "end": {
+                  "line": 5,
+                  "column": 23
+                }
+              },
+              "type": "ExpressionStatement",
+              "expression": {
+                "range": [
+                  70,
+                  90
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 22
+                  }
+                },
+                "type": "CallExpression",
+                "callee": {
+                  "range": [
+                    70,
+                    81
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 13
+                    }
+                  },
+                  "type": "MemberExpression",
+                  "computed": false,
+                  "object": {
+                    "range": [
+                      70,
+                      76
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 8
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "errors"
+                  },
+                  "property": {
+                    "range": [
+                      77,
+                      81
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 13
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "push"
+                  }
+                },
+                "arguments": [
+                  {
+                    "range": [
+                      82,
+                      89
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 21
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "message"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "finalizer": null
+    },
+    {
+      "range": [
+        95,
+        196
+      ],
+      "loc": {
+        "start": {
+          "line": 8,
+          "column": 0
+        },
+        "end": {
+          "line": 12,
+          "column": 1
+        }
+      },
+      "type": "TryStatement",
+      "block": {
+        "range": [
+          99,
+          128
+        ],
+        "loc": {
+          "start": {
+            "line": 8,
+            "column": 4
+          },
+          "end": {
+            "line": 10,
+            "column": 1
+          }
+        },
+        "type": "BlockStatement",
+        "body": [
+          {
+            "range": [
+              103,
+              126
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 2
+              },
+              "end": {
+                "line": 9,
+                "column": 25
+              }
+            },
+            "type": "ThrowStatement",
+            "argument": {
+              "range": [
+                109,
+                125
+              ],
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 8
+                },
+                "end": {
+                  "line": 9,
+                  "column": 24
+                }
+              },
+              "type": "NewExpression",
+              "callee": {
+                "range": [
+                  113,
+                  118
+                ],
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 17
+                  }
+                },
+                "type": "Identifier",
+                "name": "Error"
+              },
+              "arguments": [
+                {
+                  "range": [
+                    119,
+                    124
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 9,
+                      "column": 18
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 23
+                    }
+                  },
+                  "type": "Literal",
+                  "value": "err",
+                  "raw": "'err'"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "handler": {
+        "range": [
+          129,
+          196
+        ],
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 2
+          },
+          "end": {
+            "line": 12,
+            "column": 1
+          }
+        },
+        "type": "CatchClause",
+        "param": {
+          "range": [
+            136,
+            161
+          ],
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 9
+            },
+            "end": {
+              "line": 10,
+              "column": 34
+            }
+          },
+          "type": "ObjectPattern",
+          "properties": [
+            {
+              "range": [
+                138,
+                152
+              ],
+              "loc": {
+                "start": {
+                  "line": 10,
+                  "column": 11
+                },
+                "end": {
+                  "line": 10,
+                  "column": 25
+                }
+              },
+              "type": "Property",
+              "key": {
+                "range": [
+                  138,
+                  142
+                ],
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 15
+                  }
+                },
+                "type": "Identifier",
+                "name": "name"
+              },
+              "computed": false,
+              "value": {
+                "range": [
+                  138,
+                  152
+                ],
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 25
+                  }
+                },
+                "type": "AssignmentPattern",
+                "left": {
+                  "range": [
+                    138,
+                    142
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 10,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 15
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "name"
+                },
+                "right": {
+                  "range": [
+                    145,
+                    152
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 10,
+                      "column": 18
+                    },
+                    "end": {
+                      "line": 10,
+                      "column": 25
+                    }
+                  },
+                  "type": "Literal",
+                  "value": "Error",
+                  "raw": "'Error'"
+                }
+              },
+              "kind": "init",
+              "method": false,
+              "shorthand": true
+            },
+            {
+              "range": [
+                154,
+                159
+              ],
+              "loc": {
+                "start": {
+                  "line": 10,
+                  "column": 27
+                },
+                "end": {
+                  "line": 10,
+                  "column": 32
+                }
+              },
+              "type": "Property",
+              "key": {
+                "range": [
+                  154,
+                  159
+                ],
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 32
+                  }
+                },
+                "type": "Identifier",
+                "name": "stack"
+              },
+              "computed": false,
+              "value": {
+                "range": [
+                  154,
+                  159
+                ],
+                "loc": {
+                  "start": {
+                    "line": 10,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 32
+                  }
+                },
+                "type": "Identifier",
+                "name": "stack"
+              },
+              "kind": "init",
+              "method": false,
+              "shorthand": true
+            }
+          ]
+        },
+        "body": {
+          "range": [
+            163,
+            196
+          ],
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 36
+            },
+            "end": {
+              "line": 12,
+              "column": 1
+            }
+          },
+          "type": "BlockStatement",
+          "body": [
+            {
+              "range": [
+                167,
+                194
+              ],
+              "loc": {
+                "start": {
+                  "line": 11,
+                  "column": 2
+                },
+                "end": {
+                  "line": 11,
+                  "column": 29
+                }
+              },
+              "type": "ExpressionStatement",
+              "expression": {
+                "range": [
+                  167,
+                  193
+                ],
+                "loc": {
+                  "start": {
+                    "line": 11,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 11,
+                    "column": 28
+                  }
+                },
+                "type": "CallExpression",
+                "callee": {
+                  "range": [
+                    167,
+                    178
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 11,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 13
+                    }
+                  },
+                  "type": "MemberExpression",
+                  "computed": false,
+                  "object": {
+                    "range": [
+                      167,
+                      173
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 11,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 11,
+                        "column": 8
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "errors"
+                  },
+                  "property": {
+                    "range": [
+                      174,
+                      178
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 11,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 11,
+                        "column": 13
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "push"
+                  }
+                },
+                "arguments": [
+                  {
+                    "range": [
+                      179,
+                      192
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 11,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 11,
+                        "column": 27
+                      }
+                    },
+                    "type": "ArrayExpression",
+                    "elements": [
+                      {
+                        "range": [
+                          180,
+                          184
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 11,
+                            "column": 15
+                          },
+                          "end": {
+                            "line": 11,
+                            "column": 19
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "name"
+                      },
+                      {
+                        "range": [
+                          186,
+                          191
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 11,
+                            "column": 21
+                          },
+                          "end": {
+                            "line": 11,
+                            "column": 26
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "stack"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "finalizer": null
+    },
+    {
+      "range": [
+        198,
+        276
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 0
+        },
+        "end": {
+          "line": 18,
+          "column": 1
+        }
+      },
+      "type": "TryStatement",
+      "block": {
+        "range": [
+          202,
+          234
+        ],
+        "loc": {
+          "start": {
+            "line": 14,
+            "column": 4
+          },
+          "end": {
+            "line": 16,
+            "column": 1
+          }
+        },
+        "type": "BlockStatement",
+        "body": [
+          {
+            "range": [
+              206,
+              232
+            ],
+            "loc": {
+              "start": {
+                "line": 15,
+                "column": 2
+              },
+              "end": {
+                "line": 15,
+                "column": 28
+              }
+            },
+            "type": "ThrowStatement",
+            "argument": {
+              "range": [
+                212,
+                231
+              ],
+              "loc": {
+                "start": {
+                  "line": 15,
+                  "column": 8
+                },
+                "end": {
+                  "line": 15,
+                  "column": 27
+                }
+              },
+              "type": "ArrayExpression",
+              "elements": [
+                {
+                  "range": [
+                    213,
+                    220
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 15,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 15,
+                      "column": 16
+                    }
+                  },
+                  "type": "Literal",
+                  "value": "first",
+                  "raw": "'first'"
+                },
+                {
+                  "range": [
+                    222,
+                    230
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 15,
+                      "column": 18
+                    },
+                    "end": {
+                      "line": 15,
+                      "column": 26
+                    }
+                  },
+                  "type": "Literal",
+                  "value": "second",
+                  "raw": "'second'"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "handler": {
+        "range": [
+          235,
+          276
+        ],
+        "loc": {
+          "start": {
+            "line": 16,
+            "column": 2
+          },
+          "end": {
+            "line": 18,
+            "column": 1
+          }
+        },
+        "type": "CatchClause",
+        "param": {
+          "range": [
+            242,
+            249
+          ],
+          "loc": {
+            "start": {
+              "line": 16,
+              "column": 9
+            },
+            "end": {
+              "line": 16,
+              "column": 16
+            }
+          },
+          "type": "ArrayPattern",
+          "elements": [
+            {
+              "range": [
+                243,
+                248
+              ],
+              "loc": {
+                "start": {
+                  "line": 16,
+                  "column": 10
+                },
+                "end": {
+                  "line": 16,
+                  "column": 15
+                }
+              },
+              "type": "Identifier",
+              "name": "first"
+            }
+          ]
+        },
+        "body": {
+          "range": [
+            251,
+            276
+          ],
+          "loc": {
+            "start": {
+              "line": 16,
+              "column": 18
+            },
+            "end": {
+              "line": 18,
+              "column": 1
+            }
+          },
+          "type": "BlockStatement",
+          "body": [
+            {
+              "range": [
+                255,
+                274
+              ],
+              "loc": {
+                "start": {
+                  "line": 17,
+                  "column": 2
+                },
+                "end": {
+                  "line": 17,
+                  "column": 21
+                }
+              },
+              "type": "ExpressionStatement",
+              "expression": {
+                "range": [
+                  255,
+                  273
+                ],
+                "loc": {
+                  "start": {
+                    "line": 17,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 17,
+                    "column": 20
+                  }
+                },
+                "type": "CallExpression",
+                "callee": {
+                  "range": [
+                    255,
+                    266
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 17,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 17,
+                      "column": 13
+                    }
+                  },
+                  "type": "MemberExpression",
+                  "computed": false,
+                  "object": {
+                    "range": [
+                      255,
+                      261
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 17,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 17,
+                        "column": 8
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "errors"
+                  },
+                  "property": {
+                    "range": [
+                      262,
+                      266
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 17,
+                        "column": 9
+                      },
+                      "end": {
+                        "line": 17,
+                        "column": 13
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "push"
+                  }
+                },
+                "arguments": [
+                  {
+                    "range": [
+                      267,
+                      272
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 17,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 17,
+                        "column": 19
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "first"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "finalizer": null
+    }
+  ]
+}

--- a/tests/fixtures/test-0380-parse-expected.json
+++ b/tests/fixtures/test-0380-parse-expected.json
@@ -171,6 +171,7 @@
                 "type": "Identifier",
                 "name": "undefinedFunc"
               },
+              "optional": false,
               "arguments": []
             }
           }
@@ -334,6 +335,7 @@
                   },
                   "type": "MemberExpression",
                   "computed": false,
+                  "optional": false,
                   "object": {
                     "range": [
                       70,
@@ -371,6 +373,7 @@
                     "name": "push"
                   }
                 },
+                "optional": false,
                 "arguments": [
                   {
                     "range": [
@@ -757,6 +760,7 @@
                   },
                   "type": "MemberExpression",
                   "computed": false,
+                  "optional": false,
                   "object": {
                     "range": [
                       167,
@@ -794,6 +798,7 @@
                     "name": "push"
                   }
                 },
+                "optional": false,
                 "arguments": [
                   {
                     "range": [
@@ -1086,6 +1091,7 @@
                   },
                   "type": "MemberExpression",
                   "computed": false,
+                  "optional": false,
                   "object": {
                     "range": [
                       255,
@@ -1123,6 +1129,7 @@
                     "name": "push"
                   }
                 },
+                "optional": false,
                 "arguments": [
                   {
                     "range": [

--- a/tests/fixtures/test-0380-tokenize-expected.json
+++ b/tests/fixtures/test-0380-tokenize-expected.json
@@ -1,0 +1,346 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "errors"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "["
+  },
+  {
+    "type": "Punctuator",
+    "value": "]"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "try"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "undefinedFunc"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "message"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "errors"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "push"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "message"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "try"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "throw"
+  },
+  {
+    "type": "Keyword",
+    "value": "new"
+  },
+  {
+    "type": "Identifier",
+    "value": "Error"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "String",
+    "value": "'err'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "name"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "String",
+    "value": "'Error'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "stack"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "errors"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "push"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": "["
+  },
+  {
+    "type": "Identifier",
+    "value": "name"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "stack"
+  },
+  {
+    "type": "Punctuator",
+    "value": "]"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "try"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "throw"
+  },
+  {
+    "type": "Punctuator",
+    "value": "["
+  },
+  {
+    "type": "String",
+    "value": "'first'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "String",
+    "value": "'second'"
+  },
+  {
+    "type": "Punctuator",
+    "value": "]"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": "["
+  },
+  {
+    "type": "Identifier",
+    "value": "first"
+  },
+  {
+    "type": "Punctuator",
+    "value": "]"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "errors"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "push"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "first"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  }
+]

--- a/tests/fixtures/test-0380-tokenize-loc-range-expected.json
+++ b/tests/fixtures/test-0380-tokenize-loc-range-expected.json
@@ -1,0 +1,1550 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      0,
+      5
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "errors",
+    "range": [
+      6,
+      12
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      13,
+      14
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 13
+      },
+      "end": {
+        "line": 1,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "[",
+    "range": [
+      15,
+      16
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 15
+      },
+      "end": {
+        "line": 1,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]",
+    "range": [
+      16,
+      17
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 16
+      },
+      "end": {
+        "line": 1,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      17,
+      18
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 17
+      },
+      "end": {
+        "line": 1,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "try",
+    "range": [
+      19,
+      22
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      23,
+      24
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 4
+      },
+      "end": {
+        "line": 2,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "undefinedFunc",
+    "range": [
+      27,
+      40
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 2
+      },
+      "end": {
+        "line": 3,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      40,
+      41
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 15
+      },
+      "end": {
+        "line": 3,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      41,
+      42
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 16
+      },
+      "end": {
+        "line": 3,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      42,
+      43
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 17
+      },
+      "end": {
+        "line": 3,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      44,
+      45
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      46,
+      51
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 2
+      },
+      "end": {
+        "line": 4,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      52,
+      53
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 8
+      },
+      "end": {
+        "line": 4,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      53,
+      54
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 9
+      },
+      "end": {
+        "line": 4,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "message",
+    "range": [
+      55,
+      62
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 11
+      },
+      "end": {
+        "line": 4,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      63,
+      64
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 19
+      },
+      "end": {
+        "line": 4,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      64,
+      65
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 20
+      },
+      "end": {
+        "line": 4,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      66,
+      67
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 22
+      },
+      "end": {
+        "line": 4,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "errors",
+    "range": [
+      70,
+      76
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 2
+      },
+      "end": {
+        "line": 5,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      76,
+      77
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 8
+      },
+      "end": {
+        "line": 5,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "push",
+    "range": [
+      77,
+      81
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 9
+      },
+      "end": {
+        "line": 5,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      81,
+      82
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 13
+      },
+      "end": {
+        "line": 5,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "message",
+    "range": [
+      82,
+      89
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 14
+      },
+      "end": {
+        "line": 5,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      89,
+      90
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 21
+      },
+      "end": {
+        "line": 5,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      90,
+      91
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 22
+      },
+      "end": {
+        "line": 5,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      92,
+      93
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "try",
+    "range": [
+      95,
+      98
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 0
+      },
+      "end": {
+        "line": 8,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      99,
+      100
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 4
+      },
+      "end": {
+        "line": 8,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "throw",
+    "range": [
+      103,
+      108
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 2
+      },
+      "end": {
+        "line": 9,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "new",
+    "range": [
+      109,
+      112
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 8
+      },
+      "end": {
+        "line": 9,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "Error",
+    "range": [
+      113,
+      118
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 12
+      },
+      "end": {
+        "line": 9,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      118,
+      119
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 17
+      },
+      "end": {
+        "line": 9,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'err'",
+    "range": [
+      119,
+      124
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 18
+      },
+      "end": {
+        "line": 9,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      124,
+      125
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 23
+      },
+      "end": {
+        "line": 9,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      125,
+      126
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 24
+      },
+      "end": {
+        "line": 9,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      127,
+      128
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 0
+      },
+      "end": {
+        "line": 10,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      129,
+      134
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 2
+      },
+      "end": {
+        "line": 10,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      135,
+      136
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 8
+      },
+      "end": {
+        "line": 10,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      136,
+      137
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 9
+      },
+      "end": {
+        "line": 10,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "name",
+    "range": [
+      138,
+      142
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 11
+      },
+      "end": {
+        "line": 10,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      143,
+      144
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 16
+      },
+      "end": {
+        "line": 10,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'Error'",
+    "range": [
+      145,
+      152
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 18
+      },
+      "end": {
+        "line": 10,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      152,
+      153
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 25
+      },
+      "end": {
+        "line": 10,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "stack",
+    "range": [
+      154,
+      159
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 27
+      },
+      "end": {
+        "line": 10,
+        "column": 32
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      160,
+      161
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 33
+      },
+      "end": {
+        "line": 10,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      161,
+      162
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 34
+      },
+      "end": {
+        "line": 10,
+        "column": 35
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      163,
+      164
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 36
+      },
+      "end": {
+        "line": 10,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "errors",
+    "range": [
+      167,
+      173
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 2
+      },
+      "end": {
+        "line": 11,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      173,
+      174
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 8
+      },
+      "end": {
+        "line": 11,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "push",
+    "range": [
+      174,
+      178
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 9
+      },
+      "end": {
+        "line": 11,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      178,
+      179
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 13
+      },
+      "end": {
+        "line": 11,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "[",
+    "range": [
+      179,
+      180
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 14
+      },
+      "end": {
+        "line": 11,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "name",
+    "range": [
+      180,
+      184
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 15
+      },
+      "end": {
+        "line": 11,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      184,
+      185
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 19
+      },
+      "end": {
+        "line": 11,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "stack",
+    "range": [
+      186,
+      191
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 21
+      },
+      "end": {
+        "line": 11,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]",
+    "range": [
+      191,
+      192
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 26
+      },
+      "end": {
+        "line": 11,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      192,
+      193
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 27
+      },
+      "end": {
+        "line": 11,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      193,
+      194
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 28
+      },
+      "end": {
+        "line": 11,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      195,
+      196
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 0
+      },
+      "end": {
+        "line": 12,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "try",
+    "range": [
+      198,
+      201
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 0
+      },
+      "end": {
+        "line": 14,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      202,
+      203
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 4
+      },
+      "end": {
+        "line": 14,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "throw",
+    "range": [
+      206,
+      211
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 2
+      },
+      "end": {
+        "line": 15,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "[",
+    "range": [
+      212,
+      213
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 8
+      },
+      "end": {
+        "line": 15,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'first'",
+    "range": [
+      213,
+      220
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 9
+      },
+      "end": {
+        "line": 15,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      220,
+      221
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 16
+      },
+      "end": {
+        "line": 15,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'second'",
+    "range": [
+      222,
+      230
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 18
+      },
+      "end": {
+        "line": 15,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]",
+    "range": [
+      230,
+      231
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 26
+      },
+      "end": {
+        "line": 15,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      231,
+      232
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 27
+      },
+      "end": {
+        "line": 15,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      233,
+      234
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 0
+      },
+      "end": {
+        "line": 16,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      235,
+      240
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 2
+      },
+      "end": {
+        "line": 16,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      241,
+      242
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 8
+      },
+      "end": {
+        "line": 16,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "[",
+    "range": [
+      242,
+      243
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 9
+      },
+      "end": {
+        "line": 16,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "first",
+    "range": [
+      243,
+      248
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 10
+      },
+      "end": {
+        "line": 16,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]",
+    "range": [
+      248,
+      249
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 15
+      },
+      "end": {
+        "line": 16,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      249,
+      250
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 16
+      },
+      "end": {
+        "line": 16,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      251,
+      252
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 18
+      },
+      "end": {
+        "line": 16,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "errors",
+    "range": [
+      255,
+      261
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 2
+      },
+      "end": {
+        "line": 17,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      261,
+      262
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 8
+      },
+      "end": {
+        "line": 17,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "push",
+    "range": [
+      262,
+      266
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 9
+      },
+      "end": {
+        "line": 17,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      266,
+      267
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 13
+      },
+      "end": {
+        "line": 17,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "first",
+    "range": [
+      267,
+      272
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 14
+      },
+      "end": {
+        "line": 17,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      272,
+      273
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 19
+      },
+      "end": {
+        "line": 17,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      273,
+      274
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 20
+      },
+      "end": {
+        "line": 17,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      275,
+      276
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 0
+      },
+      "end": {
+        "line": 18,
+        "column": 1
+      }
+    }
+  }
+]

--- a/tests/fixtures/test-0380.js
+++ b/tests/fixtures/test-0380.js
@@ -1,0 +1,18 @@
+const errors = [];
+try {
+  undefinedFunc();
+} catch ({ message }) {
+  errors.push(message);
+}
+
+try {
+  throw new Error('err');
+} catch ({ name = 'Error', stack }) {
+  errors.push([name, stack]);
+}
+
+try {
+  throw ['first', 'second'];
+} catch ([first]) {
+  errors.push(first);
+}

--- a/tests/fixtures/test-0381-parse-expected.json
+++ b/tests/fixtures/test-0381-parse-expected.json
@@ -1,0 +1,782 @@
+{
+  "range": [
+    0,
+    212
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 19,
+      "column": 1
+    }
+  },
+  "type": "Program",
+  "body": [
+    {
+      "range": [
+        0,
+        14
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 14
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            4,
+            13
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 4
+            },
+            "end": {
+              "line": 1,
+              "column": 13
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              4,
+              9
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "count"
+          },
+          "init": {
+            "range": [
+              12,
+              13
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 12
+              },
+              "end": {
+                "line": 1,
+                "column": 13
+              }
+            },
+            "type": "Literal",
+            "value": 0,
+            "raw": "0"
+          }
+        }
+      ],
+      "kind": "let"
+    },
+    {
+      "range": [
+        16,
+        212
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 19,
+          "column": 1
+        }
+      },
+      "type": "TryStatement",
+      "block": {
+        "range": [
+          20,
+          110
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 4
+          },
+          "end": {
+            "line": 11,
+            "column": 1
+          }
+        },
+        "type": "BlockStatement",
+        "body": [
+          {
+            "range": [
+              24,
+              108
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 2
+              },
+              "end": {
+                "line": 10,
+                "column": 3
+              }
+            },
+            "type": "TryStatement",
+            "block": {
+              "range": [
+                28,
+                62
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 6
+                },
+                "end": {
+                  "line": 7,
+                  "column": 3
+                }
+              },
+              "type": "BlockStatement",
+              "body": [
+                {
+                  "range": [
+                    34,
+                    42
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 12
+                    }
+                  },
+                  "type": "ExpressionStatement",
+                  "expression": {
+                    "range": [
+                      34,
+                      41
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 11
+                      }
+                    },
+                    "type": "UpdateExpression",
+                    "operator": "++",
+                    "argument": {
+                      "range": [
+                        34,
+                        39
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 9
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "count"
+                    },
+                    "prefix": false
+                  }
+                },
+                {
+                  "range": [
+                    47,
+                    58
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 4
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 15
+                    }
+                  },
+                  "type": "ExpressionStatement",
+                  "expression": {
+                    "range": [
+                      47,
+                      57
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 6,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 6,
+                        "column": 14
+                      }
+                    },
+                    "type": "MemberExpression",
+                    "computed": false,
+                    "object": {
+                      "range": [
+                        47,
+                        51
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 6,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 6,
+                          "column": 8
+                        }
+                      },
+                      "type": "Literal",
+                      "value": null,
+                      "raw": "null"
+                    },
+                    "property": {
+                      "range": [
+                        52,
+                        57
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 6,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 6,
+                          "column": 14
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "value"
+                    }
+                  }
+                }
+              ]
+            },
+            "handler": {
+              "range": [
+                63,
+                108
+              ],
+              "loc": {
+                "start": {
+                  "line": 7,
+                  "column": 4
+                },
+                "end": {
+                  "line": 10,
+                  "column": 3
+                }
+              },
+              "type": "CatchClause",
+              "param": null,
+              "body": {
+                "range": [
+                  69,
+                  108
+                ],
+                "loc": {
+                  "start": {
+                    "line": 7,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 10,
+                    "column": 3
+                  }
+                },
+                "type": "BlockStatement",
+                "body": [
+                  {
+                    "range": [
+                      75,
+                      83
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 8,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 8,
+                        "column": 12
+                      }
+                    },
+                    "type": "ExpressionStatement",
+                    "expression": {
+                      "range": [
+                        75,
+                        82
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 8,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 8,
+                          "column": 11
+                        }
+                      },
+                      "type": "UpdateExpression",
+                      "operator": "++",
+                      "argument": {
+                        "range": [
+                          75,
+                          80
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 8,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 8,
+                            "column": 9
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "count"
+                      },
+                      "prefix": false
+                    }
+                  },
+                  {
+                    "range": [
+                      88,
+                      104
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 9,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 9,
+                        "column": 20
+                      }
+                    },
+                    "type": "ExpressionStatement",
+                    "expression": {
+                      "range": [
+                        88,
+                        103
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 9,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 9,
+                          "column": 19
+                        }
+                      },
+                      "type": "MemberExpression",
+                      "computed": false,
+                      "object": {
+                        "range": [
+                          88,
+                          97
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 9,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 9,
+                            "column": 13
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "undefined"
+                      },
+                      "property": {
+                        "range": [
+                          98,
+                          103
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 9,
+                            "column": 14
+                          },
+                          "end": {
+                            "line": 9,
+                            "column": 19
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "value"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "finalizer": null
+          }
+        ]
+      },
+      "handler": {
+        "range": [
+          111,
+          189
+        ],
+        "loc": {
+          "start": {
+            "line": 11,
+            "column": 2
+          },
+          "end": {
+            "line": 17,
+            "column": 1
+          }
+        },
+        "type": "CatchClause",
+        "param": {
+          "range": [
+            118,
+            119
+          ],
+          "loc": {
+            "start": {
+              "line": 11,
+              "column": 9
+            },
+            "end": {
+              "line": 11,
+              "column": 10
+            }
+          },
+          "type": "Identifier",
+          "name": "e"
+        },
+        "body": {
+          "range": [
+            121,
+            189
+          ],
+          "loc": {
+            "start": {
+              "line": 11,
+              "column": 12
+            },
+            "end": {
+              "line": 17,
+              "column": 1
+            }
+          },
+          "type": "BlockStatement",
+          "body": [
+            {
+              "range": [
+                125,
+                187
+              ],
+              "loc": {
+                "start": {
+                  "line": 12,
+                  "column": 2
+                },
+                "end": {
+                  "line": 16,
+                  "column": 3
+                }
+              },
+              "type": "TryStatement",
+              "block": {
+                "range": [
+                  129,
+                  162
+                ],
+                "loc": {
+                  "start": {
+                    "line": 12,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 3
+                  }
+                },
+                "type": "BlockStatement",
+                "body": [
+                  {
+                    "range": [
+                      135,
+                      158
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 13,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 13,
+                        "column": 27
+                      }
+                    },
+                    "type": "ThrowStatement",
+                    "argument": {
+                      "range": [
+                        141,
+                        157
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 13,
+                          "column": 10
+                        },
+                        "end": {
+                          "line": 13,
+                          "column": 26
+                        }
+                      },
+                      "type": "NewExpression",
+                      "callee": {
+                        "range": [
+                          145,
+                          150
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 13,
+                            "column": 14
+                          },
+                          "end": {
+                            "line": 13,
+                            "column": 19
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "Error"
+                      },
+                      "arguments": [
+                        {
+                          "range": [
+                            151,
+                            156
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 13,
+                              "column": 20
+                            },
+                            "end": {
+                              "line": 13,
+                              "column": 25
+                            }
+                          },
+                          "type": "Literal",
+                          "value": "err",
+                          "raw": "'err'"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "handler": {
+                "range": [
+                  163,
+                  187
+                ],
+                "loc": {
+                  "start": {
+                    "line": 14,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 16,
+                    "column": 3
+                  }
+                },
+                "type": "CatchClause",
+                "param": null,
+                "body": {
+                  "range": [
+                    169,
+                    187
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 14,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 16,
+                      "column": 3
+                    }
+                  },
+                  "type": "BlockStatement",
+                  "body": [
+                    {
+                      "range": [
+                        175,
+                        183
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 15,
+                          "column": 4
+                        },
+                        "end": {
+                          "line": 15,
+                          "column": 12
+                        }
+                      },
+                      "type": "ExpressionStatement",
+                      "expression": {
+                        "range": [
+                          175,
+                          182
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 15,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 15,
+                            "column": 11
+                          }
+                        },
+                        "type": "UpdateExpression",
+                        "operator": "++",
+                        "argument": {
+                          "range": [
+                            175,
+                            180
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 15,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 15,
+                              "column": 9
+                            }
+                          },
+                          "type": "Identifier",
+                          "name": "count"
+                        },
+                        "prefix": false
+                      }
+                    }
+                  ]
+                }
+              },
+              "finalizer": null
+            }
+          ]
+        }
+      },
+      "finalizer": {
+        "range": [
+          198,
+          212
+        ],
+        "loc": {
+          "start": {
+            "line": 17,
+            "column": 10
+          },
+          "end": {
+            "line": 19,
+            "column": 1
+          }
+        },
+        "type": "BlockStatement",
+        "body": [
+          {
+            "range": [
+              202,
+              210
+            ],
+            "loc": {
+              "start": {
+                "line": 18,
+                "column": 2
+              },
+              "end": {
+                "line": 18,
+                "column": 10
+              }
+            },
+            "type": "ExpressionStatement",
+            "expression": {
+              "range": [
+                202,
+                209
+              ],
+              "loc": {
+                "start": {
+                  "line": 18,
+                  "column": 2
+                },
+                "end": {
+                  "line": 18,
+                  "column": 9
+                }
+              },
+              "type": "UpdateExpression",
+              "operator": "++",
+              "argument": {
+                "range": [
+                  202,
+                  207
+                ],
+                "loc": {
+                  "start": {
+                    "line": 18,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 18,
+                    "column": 7
+                  }
+                },
+                "type": "Identifier",
+                "name": "count"
+              },
+              "prefix": false
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/test-0381-parse-expected.json
+++ b/tests/fixtures/test-0381-parse-expected.json
@@ -242,6 +242,7 @@
                     },
                     "type": "MemberExpression",
                     "computed": false,
+                    "optional": false,
                     "object": {
                       "range": [
                         47,
@@ -404,6 +405,7 @@
                       },
                       "type": "MemberExpression",
                       "computed": false,
+                      "optional": false,
                       "object": {
                         "range": [
                           88,

--- a/tests/fixtures/test-0381-tokenize-expected.json
+++ b/tests/fixtures/test-0381-tokenize-expected.json
@@ -1,0 +1,226 @@
+[
+  {
+    "type": "Keyword",
+    "value": "let"
+  },
+  {
+    "type": "Identifier",
+    "value": "count"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "try"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "try"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "count"
+  },
+  {
+    "type": "Punctuator",
+    "value": "++"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Null",
+    "value": "null"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "value"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "count"
+  },
+  {
+    "type": "Punctuator",
+    "value": "++"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Identifier",
+    "value": "undefined"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "value"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "e"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "try"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "throw"
+  },
+  {
+    "type": "Keyword",
+    "value": "new"
+  },
+  {
+    "type": "Identifier",
+    "value": "Error"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "String",
+    "value": "'err'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "count"
+  },
+  {
+    "type": "Punctuator",
+    "value": "++"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "finally"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "count"
+  },
+  {
+    "type": "Punctuator",
+    "value": "++"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  }
+]

--- a/tests/fixtures/test-0381-tokenize-loc-range-expected.json
+++ b/tests/fixtures/test-0381-tokenize-loc-range-expected.json
@@ -1,0 +1,1010 @@
+[
+  {
+    "type": "Keyword",
+    "value": "let",
+    "range": [
+      0,
+      3
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "count",
+    "range": [
+      4,
+      9
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 4
+      },
+      "end": {
+        "line": 1,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      10,
+      11
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 10
+      },
+      "end": {
+        "line": 1,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      12,
+      13
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 12
+      },
+      "end": {
+        "line": 1,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      13,
+      14
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 13
+      },
+      "end": {
+        "line": 1,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "try",
+    "range": [
+      16,
+      19
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      20,
+      21
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 4
+      },
+      "end": {
+        "line": 3,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "try",
+    "range": [
+      24,
+      27
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 2
+      },
+      "end": {
+        "line": 4,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      28,
+      29
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 6
+      },
+      "end": {
+        "line": 4,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "count",
+    "range": [
+      34,
+      39
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 4
+      },
+      "end": {
+        "line": 5,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "++",
+    "range": [
+      39,
+      41
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 9
+      },
+      "end": {
+        "line": 5,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      41,
+      42
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 11
+      },
+      "end": {
+        "line": 5,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Null",
+    "value": "null",
+    "range": [
+      47,
+      51
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 4
+      },
+      "end": {
+        "line": 6,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      51,
+      52
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 8
+      },
+      "end": {
+        "line": 6,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "value",
+    "range": [
+      52,
+      57
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 9
+      },
+      "end": {
+        "line": 6,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      57,
+      58
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 14
+      },
+      "end": {
+        "line": 6,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      61,
+      62
+    ],
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 2
+      },
+      "end": {
+        "line": 7,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      63,
+      68
+    ],
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 4
+      },
+      "end": {
+        "line": 7,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      69,
+      70
+    ],
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 10
+      },
+      "end": {
+        "line": 7,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "count",
+    "range": [
+      75,
+      80
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 4
+      },
+      "end": {
+        "line": 8,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "++",
+    "range": [
+      80,
+      82
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 9
+      },
+      "end": {
+        "line": 8,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      82,
+      83
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 11
+      },
+      "end": {
+        "line": 8,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "undefined",
+    "range": [
+      88,
+      97
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 4
+      },
+      "end": {
+        "line": 9,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      97,
+      98
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 13
+      },
+      "end": {
+        "line": 9,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "value",
+    "range": [
+      98,
+      103
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 14
+      },
+      "end": {
+        "line": 9,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      103,
+      104
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 19
+      },
+      "end": {
+        "line": 9,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      107,
+      108
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 2
+      },
+      "end": {
+        "line": 10,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      109,
+      110
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 0
+      },
+      "end": {
+        "line": 11,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      111,
+      116
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 2
+      },
+      "end": {
+        "line": 11,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      117,
+      118
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 8
+      },
+      "end": {
+        "line": 11,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "e",
+    "range": [
+      118,
+      119
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 9
+      },
+      "end": {
+        "line": 11,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      119,
+      120
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 10
+      },
+      "end": {
+        "line": 11,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      121,
+      122
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 12
+      },
+      "end": {
+        "line": 11,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "try",
+    "range": [
+      125,
+      128
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 2
+      },
+      "end": {
+        "line": 12,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      129,
+      130
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 6
+      },
+      "end": {
+        "line": 12,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "throw",
+    "range": [
+      135,
+      140
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 4
+      },
+      "end": {
+        "line": 13,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "new",
+    "range": [
+      141,
+      144
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 10
+      },
+      "end": {
+        "line": 13,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "Error",
+    "range": [
+      145,
+      150
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 14
+      },
+      "end": {
+        "line": 13,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      150,
+      151
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 19
+      },
+      "end": {
+        "line": 13,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'err'",
+    "range": [
+      151,
+      156
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 20
+      },
+      "end": {
+        "line": 13,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      156,
+      157
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 25
+      },
+      "end": {
+        "line": 13,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      157,
+      158
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 26
+      },
+      "end": {
+        "line": 13,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      161,
+      162
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 2
+      },
+      "end": {
+        "line": 14,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      163,
+      168
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 4
+      },
+      "end": {
+        "line": 14,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      169,
+      170
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 10
+      },
+      "end": {
+        "line": 14,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "count",
+    "range": [
+      175,
+      180
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 4
+      },
+      "end": {
+        "line": 15,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "++",
+    "range": [
+      180,
+      182
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 9
+      },
+      "end": {
+        "line": 15,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      182,
+      183
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 11
+      },
+      "end": {
+        "line": 15,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      186,
+      187
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 2
+      },
+      "end": {
+        "line": 16,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      188,
+      189
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 0
+      },
+      "end": {
+        "line": 17,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "finally",
+    "range": [
+      190,
+      197
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 2
+      },
+      "end": {
+        "line": 17,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      198,
+      199
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 10
+      },
+      "end": {
+        "line": 17,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "count",
+    "range": [
+      202,
+      207
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 2
+      },
+      "end": {
+        "line": 18,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "++",
+    "range": [
+      207,
+      209
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 7
+      },
+      "end": {
+        "line": 18,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      209,
+      210
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 9
+      },
+      "end": {
+        "line": 18,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      211,
+      212
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 0
+      },
+      "end": {
+        "line": 19,
+        "column": 1
+      }
+    }
+  }
+]

--- a/tests/fixtures/test-0381.js
+++ b/tests/fixtures/test-0381.js
@@ -1,0 +1,19 @@
+let count = 0;
+
+try {
+  try {
+    count++;
+    null.value;
+  } catch {
+    count++;
+    undefined.value;
+  }
+} catch (e) {
+  try {
+    throw new Error('err');
+  } catch {
+    count++;
+  }
+} finally {
+  count++;
+}

--- a/tests/fixtures/test-0382-parse-expected.json
+++ b/tests/fixtures/test-0382-parse-expected.json
@@ -1,0 +1,1402 @@
+{
+  "range": [
+    0,
+    325
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 18,
+      "column": 32
+    }
+  },
+  "type": "Program",
+  "body": [
+    {
+      "range": [
+        0,
+        19
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 19
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            6,
+            18
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 18
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              6,
+              13
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 1,
+                "column": 13
+              }
+            },
+            "type": "Identifier",
+            "name": "results"
+          },
+          "init": {
+            "range": [
+              16,
+              18
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 16
+              },
+              "end": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "type": "ArrayExpression",
+            "elements": []
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        21,
+        151
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 6,
+          "column": 39
+        }
+      },
+      "type": "ExpressionStatement",
+      "expression": {
+        "range": [
+          21,
+          150
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 6,
+            "column": 38
+          }
+        },
+        "type": "CallExpression",
+        "callee": {
+          "range": [
+            21,
+            122
+          ],
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 0
+            },
+            "end": {
+              "line": 6,
+              "column": 10
+            }
+          },
+          "type": "MemberExpression",
+          "computed": false,
+          "object": {
+            "range": [
+              21,
+              111
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 0
+              },
+              "end": {
+                "line": 5,
+                "column": 40
+              }
+            },
+            "type": "CallExpression",
+            "callee": {
+              "range": [
+                21,
+                79
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 0
+                },
+                "end": {
+                  "line": 5,
+                  "column": 8
+                }
+              },
+              "type": "MemberExpression",
+              "computed": false,
+              "object": {
+                "range": [
+                  21,
+                  70
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 0
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 29
+                  }
+                },
+                "type": "CallExpression",
+                "callee": {
+                  "range": [
+                    21,
+                    48
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 3,
+                      "column": 0
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 7
+                    }
+                  },
+                  "type": "MemberExpression",
+                  "computed": false,
+                  "object": {
+                    "range": [
+                      21,
+                      40
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 3,
+                        "column": 0
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 19
+                      }
+                    },
+                    "type": "CallExpression",
+                    "callee": {
+                      "range": [
+                        21,
+                        36
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 3,
+                          "column": 0
+                        },
+                        "end": {
+                          "line": 3,
+                          "column": 15
+                        }
+                      },
+                      "type": "MemberExpression",
+                      "computed": false,
+                      "object": {
+                        "range": [
+                          21,
+                          28
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 0
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 7
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "Promise"
+                      },
+                      "property": {
+                        "range": [
+                          29,
+                          36
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 8
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 15
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "resolve"
+                      }
+                    },
+                    "arguments": [
+                      {
+                        "range": [
+                          37,
+                          39
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 3,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 18
+                          }
+                        },
+                        "type": "Literal",
+                        "value": 42,
+                        "raw": "42"
+                      }
+                    ]
+                  },
+                  "property": {
+                    "range": [
+                      44,
+                      48
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 7
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "then"
+                  }
+                },
+                "arguments": [
+                  {
+                    "range": [
+                      49,
+                      69
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 4,
+                        "column": 8
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 28
+                      }
+                    },
+                    "type": "ArrowFunctionExpression",
+                    "params": [
+                      {
+                        "range": [
+                          50,
+                          55
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 14
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "value"
+                      }
+                    ],
+                    "body": {
+                      "range": [
+                        60,
+                        69
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 4,
+                          "column": 19
+                        },
+                        "end": {
+                          "line": 4,
+                          "column": 28
+                        }
+                      },
+                      "type": "BinaryExpression",
+                      "operator": "+",
+                      "left": {
+                        "range": [
+                          60,
+                          65
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 19
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 24
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "value"
+                      },
+                      "right": {
+                        "range": [
+                          68,
+                          69
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 4,
+                            "column": 27
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 28
+                          }
+                        },
+                        "type": "Literal",
+                        "value": 1,
+                        "raw": "1"
+                      }
+                    },
+                    "expression": true
+                  }
+                ]
+              },
+              "property": {
+                "range": [
+                  74,
+                  79
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 8
+                  }
+                },
+                "type": "Identifier",
+                "name": "catch"
+              }
+            },
+            "arguments": [
+              {
+                "range": [
+                  80,
+                  110
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 39
+                  }
+                },
+                "type": "ArrowFunctionExpression",
+                "params": [
+                  {
+                    "range": [
+                      81,
+                      86
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 10
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 15
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "error"
+                  }
+                ],
+                "body": {
+                  "range": [
+                    91,
+                    110
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 20
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 39
+                    }
+                  },
+                  "type": "CallExpression",
+                  "callee": {
+                    "range": [
+                      91,
+                      103
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 20
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 32
+                      }
+                    },
+                    "type": "MemberExpression",
+                    "computed": false,
+                    "object": {
+                      "range": [
+                        91,
+                        98
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 20
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 27
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "results"
+                    },
+                    "property": {
+                      "range": [
+                        99,
+                        103
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 28
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 32
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "push"
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "range": [
+                        104,
+                        109
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 33
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 38
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "error"
+                    }
+                  ]
+                },
+                "expression": true
+              }
+            ]
+          },
+          "property": {
+            "range": [
+              115,
+              122
+            ],
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 3
+              },
+              "end": {
+                "line": 6,
+                "column": 10
+              }
+            },
+            "type": "Identifier",
+            "name": "finally"
+          }
+        },
+        "arguments": [
+          {
+            "range": [
+              123,
+              149
+            ],
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 11
+              },
+              "end": {
+                "line": 6,
+                "column": 37
+              }
+            },
+            "type": "ArrowFunctionExpression",
+            "params": [],
+            "body": {
+              "range": [
+                129,
+                149
+              ],
+              "loc": {
+                "start": {
+                  "line": 6,
+                  "column": 17
+                },
+                "end": {
+                  "line": 6,
+                  "column": 37
+                }
+              },
+              "type": "CallExpression",
+              "callee": {
+                "range": [
+                  129,
+                  141
+                ],
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 29
+                  }
+                },
+                "type": "MemberExpression",
+                "computed": false,
+                "object": {
+                  "range": [
+                    129,
+                    136
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 24
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "results"
+                },
+                "property": {
+                  "range": [
+                    137,
+                    141
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 25
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 29
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "push"
+                }
+              },
+              "arguments": [
+                {
+                  "range": [
+                    142,
+                    148
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 30
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 36
+                    }
+                  },
+                  "type": "Literal",
+                  "value": "done",
+                  "raw": "'done'"
+                }
+              ]
+            },
+            "expression": true
+          }
+        ]
+      }
+    },
+    {
+      "range": [
+        153,
+        252
+      ],
+      "loc": {
+        "start": {
+          "line": 8,
+          "column": 0
+        },
+        "end": {
+          "line": 15,
+          "column": 2
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            159,
+            251
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 6
+            },
+            "end": {
+              "line": 15,
+              "column": 1
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              159,
+              166
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 6
+              },
+              "end": {
+                "line": 8,
+                "column": 13
+              }
+            },
+            "type": "Identifier",
+            "name": "wrapper"
+          },
+          "init": {
+            "range": [
+              169,
+              251
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 16
+              },
+              "end": {
+                "line": 15,
+                "column": 1
+              }
+            },
+            "type": "ObjectExpression",
+            "properties": [
+              {
+                "range": [
+                  173,
+                  213
+                ],
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 11,
+                    "column": 3
+                  }
+                },
+                "type": "Property",
+                "key": {
+                  "range": [
+                    173,
+                    178
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 9,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 9,
+                      "column": 7
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "catch"
+                },
+                "computed": false,
+                "value": {
+                  "range": [
+                    178,
+                    213
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 9,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 3
+                    }
+                  },
+                  "type": "FunctionExpression",
+                  "id": null,
+                  "params": [
+                    {
+                      "range": [
+                        179,
+                        186
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 9,
+                          "column": 8
+                        },
+                        "end": {
+                          "line": 9,
+                          "column": 15
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "handler"
+                    }
+                  ],
+                  "body": {
+                    "range": [
+                      188,
+                      213
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 9,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 11,
+                        "column": 3
+                      }
+                    },
+                    "type": "BlockStatement",
+                    "body": [
+                      {
+                        "range": [
+                          194,
+                          209
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 10,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 10,
+                            "column": 19
+                          }
+                        },
+                        "type": "ReturnStatement",
+                        "argument": {
+                          "range": [
+                            201,
+                            208
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 10,
+                              "column": 11
+                            },
+                            "end": {
+                              "line": 10,
+                              "column": 18
+                            }
+                          },
+                          "type": "Identifier",
+                          "name": "handler"
+                        }
+                      }
+                    ]
+                  },
+                  "generator": false,
+                  "expression": false
+                },
+                "kind": "init",
+                "method": true,
+                "shorthand": false
+              },
+              {
+                "range": [
+                  217,
+                  249
+                ],
+                "loc": {
+                  "start": {
+                    "line": 12,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 3
+                  }
+                },
+                "type": "Property",
+                "key": {
+                  "range": [
+                    217,
+                    224
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 12,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 9
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "finally"
+                },
+                "computed": false,
+                "value": {
+                  "range": [
+                    224,
+                    249
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 12,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 14,
+                      "column": 3
+                    }
+                  },
+                  "type": "FunctionExpression",
+                  "id": null,
+                  "params": [],
+                  "body": {
+                    "range": [
+                      227,
+                      249
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 12,
+                        "column": 12
+                      },
+                      "end": {
+                        "line": 14,
+                        "column": 3
+                      }
+                    },
+                    "type": "BlockStatement",
+                    "body": [
+                      {
+                        "range": [
+                          233,
+                          245
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 13,
+                            "column": 4
+                          },
+                          "end": {
+                            "line": 13,
+                            "column": 16
+                          }
+                        },
+                        "type": "ReturnStatement",
+                        "argument": {
+                          "range": [
+                            240,
+                            244
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 13,
+                              "column": 11
+                            },
+                            "end": {
+                              "line": 13,
+                              "column": 15
+                            }
+                          },
+                          "type": "Literal",
+                          "value": true,
+                          "raw": "true"
+                        }
+                      }
+                    ]
+                  },
+                  "generator": false,
+                  "expression": false
+                },
+                "kind": "init",
+                "method": true,
+                "shorthand": false
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        254,
+        292
+      ],
+      "loc": {
+        "start": {
+          "line": 17,
+          "column": 0
+        },
+        "end": {
+          "line": 17,
+          "column": 38
+        }
+      },
+      "type": "ExpressionStatement",
+      "expression": {
+        "range": [
+          254,
+          291
+        ],
+        "loc": {
+          "start": {
+            "line": 17,
+            "column": 0
+          },
+          "end": {
+            "line": 17,
+            "column": 37
+          }
+        },
+        "type": "CallExpression",
+        "callee": {
+          "range": [
+            254,
+            266
+          ],
+          "loc": {
+            "start": {
+              "line": 17,
+              "column": 0
+            },
+            "end": {
+              "line": 17,
+              "column": 12
+            }
+          },
+          "type": "MemberExpression",
+          "computed": false,
+          "object": {
+            "range": [
+              254,
+              261
+            ],
+            "loc": {
+              "start": {
+                "line": 17,
+                "column": 0
+              },
+              "end": {
+                "line": 17,
+                "column": 7
+              }
+            },
+            "type": "Identifier",
+            "name": "results"
+          },
+          "property": {
+            "range": [
+              262,
+              266
+            ],
+            "loc": {
+              "start": {
+                "line": 17,
+                "column": 8
+              },
+              "end": {
+                "line": 17,
+                "column": 12
+              }
+            },
+            "type": "Identifier",
+            "name": "push"
+          }
+        },
+        "arguments": [
+          {
+            "range": [
+              267,
+              290
+            ],
+            "loc": {
+              "start": {
+                "line": 17,
+                "column": 13
+              },
+              "end": {
+                "line": 17,
+                "column": 36
+              }
+            },
+            "type": "CallExpression",
+            "callee": {
+              "range": [
+                267,
+                280
+              ],
+              "loc": {
+                "start": {
+                  "line": 17,
+                  "column": 13
+                },
+                "end": {
+                  "line": 17,
+                  "column": 26
+                }
+              },
+              "type": "MemberExpression",
+              "computed": false,
+              "object": {
+                "range": [
+                  267,
+                  274
+                ],
+                "loc": {
+                  "start": {
+                    "line": 17,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 17,
+                    "column": 20
+                  }
+                },
+                "type": "Identifier",
+                "name": "wrapper"
+              },
+              "property": {
+                "range": [
+                  275,
+                  280
+                ],
+                "loc": {
+                  "start": {
+                    "line": 17,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 17,
+                    "column": 26
+                  }
+                },
+                "type": "Identifier",
+                "name": "catch"
+              }
+            },
+            "arguments": [
+              {
+                "range": [
+                  281,
+                  289
+                ],
+                "loc": {
+                  "start": {
+                    "line": 17,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 17,
+                    "column": 35
+                  }
+                },
+                "type": "ArrowFunctionExpression",
+                "params": [
+                  {
+                    "range": [
+                      282,
+                      283
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 17,
+                        "column": 28
+                      },
+                      "end": {
+                        "line": 17,
+                        "column": 29
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "e"
+                  }
+                ],
+                "body": {
+                  "range": [
+                    288,
+                    289
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 17,
+                      "column": 34
+                    },
+                    "end": {
+                      "line": 17,
+                      "column": 35
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "e"
+                },
+                "expression": true
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "range": [
+        293,
+        325
+      ],
+      "loc": {
+        "start": {
+          "line": 18,
+          "column": 0
+        },
+        "end": {
+          "line": 18,
+          "column": 32
+        }
+      },
+      "type": "ExpressionStatement",
+      "expression": {
+        "range": [
+          293,
+          324
+        ],
+        "loc": {
+          "start": {
+            "line": 18,
+            "column": 0
+          },
+          "end": {
+            "line": 18,
+            "column": 31
+          }
+        },
+        "type": "CallExpression",
+        "callee": {
+          "range": [
+            293,
+            305
+          ],
+          "loc": {
+            "start": {
+              "line": 18,
+              "column": 0
+            },
+            "end": {
+              "line": 18,
+              "column": 12
+            }
+          },
+          "type": "MemberExpression",
+          "computed": false,
+          "object": {
+            "range": [
+              293,
+              300
+            ],
+            "loc": {
+              "start": {
+                "line": 18,
+                "column": 0
+              },
+              "end": {
+                "line": 18,
+                "column": 7
+              }
+            },
+            "type": "Identifier",
+            "name": "results"
+          },
+          "property": {
+            "range": [
+              301,
+              305
+            ],
+            "loc": {
+              "start": {
+                "line": 18,
+                "column": 8
+              },
+              "end": {
+                "line": 18,
+                "column": 12
+              }
+            },
+            "type": "Identifier",
+            "name": "push"
+          }
+        },
+        "arguments": [
+          {
+            "range": [
+              306,
+              323
+            ],
+            "loc": {
+              "start": {
+                "line": 18,
+                "column": 13
+              },
+              "end": {
+                "line": 18,
+                "column": 30
+              }
+            },
+            "type": "CallExpression",
+            "callee": {
+              "range": [
+                306,
+                321
+              ],
+              "loc": {
+                "start": {
+                  "line": 18,
+                  "column": 13
+                },
+                "end": {
+                  "line": 18,
+                  "column": 28
+                }
+              },
+              "type": "MemberExpression",
+              "computed": false,
+              "object": {
+                "range": [
+                  306,
+                  313
+                ],
+                "loc": {
+                  "start": {
+                    "line": 18,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 18,
+                    "column": 20
+                  }
+                },
+                "type": "Identifier",
+                "name": "wrapper"
+              },
+              "property": {
+                "range": [
+                  314,
+                  321
+                ],
+                "loc": {
+                  "start": {
+                    "line": 18,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 18,
+                    "column": 28
+                  }
+                },
+                "type": "Identifier",
+                "name": "finally"
+              }
+            },
+            "arguments": []
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/test-0382-parse-expected.json
+++ b/tests/fixtures/test-0382-parse-expected.json
@@ -137,6 +137,7 @@
           },
           "type": "MemberExpression",
           "computed": false,
+          "optional": false,
           "object": {
             "range": [
               21,
@@ -170,6 +171,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   21,
@@ -203,6 +205,7 @@
                   },
                   "type": "MemberExpression",
                   "computed": false,
+                  "optional": false,
                   "object": {
                     "range": [
                       21,
@@ -236,6 +239,7 @@
                       },
                       "type": "MemberExpression",
                       "computed": false,
+                      "optional": false,
                       "object": {
                         "range": [
                           21,
@@ -273,6 +277,7 @@
                         "name": "resolve"
                       }
                     },
+                    "optional": false,
                     "arguments": [
                       {
                         "range": [
@@ -314,6 +319,7 @@
                     "name": "then"
                   }
                 },
+                "optional": false,
                 "arguments": [
                   {
                     "range": [
@@ -429,6 +435,7 @@
                 "name": "catch"
               }
             },
+            "optional": false,
             "arguments": [
               {
                 "range": [
@@ -499,6 +506,7 @@
                     },
                     "type": "MemberExpression",
                     "computed": false,
+                    "optional": false,
                     "object": {
                       "range": [
                         91,
@@ -536,6 +544,7 @@
                       "name": "push"
                     }
                   },
+                  "optional": false,
                   "arguments": [
                     {
                       "range": [
@@ -580,6 +589,7 @@
             "name": "finally"
           }
         },
+        "optional": false,
         "arguments": [
           {
             "range": [
@@ -631,6 +641,7 @@
                 },
                 "type": "MemberExpression",
                 "computed": false,
+                "optional": false,
                 "object": {
                   "range": [
                     129,
@@ -668,6 +679,7 @@
                   "name": "push"
                 }
               },
+              "optional": false,
               "arguments": [
                 {
                   "range": [
@@ -1066,6 +1078,7 @@
           },
           "type": "MemberExpression",
           "computed": false,
+          "optional": false,
           "object": {
             "range": [
               254,
@@ -1103,6 +1116,7 @@
             "name": "push"
           }
         },
+        "optional": false,
         "arguments": [
           {
             "range": [
@@ -1137,6 +1151,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   267,
@@ -1174,6 +1189,7 @@
                 "name": "catch"
               }
             },
+            "optional": false,
             "arguments": [
               {
                 "range": [
@@ -1285,6 +1301,7 @@
           },
           "type": "MemberExpression",
           "computed": false,
+          "optional": false,
           "object": {
             "range": [
               293,
@@ -1322,6 +1339,7 @@
             "name": "push"
           }
         },
+        "optional": false,
         "arguments": [
           {
             "range": [
@@ -1356,6 +1374,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   306,
@@ -1393,6 +1412,7 @@
                 "name": "finally"
               }
             },
+            "optional": false,
             "arguments": []
           }
         ]

--- a/tests/fixtures/test-0382-tokenize-expected.json
+++ b/tests/fixtures/test-0382-tokenize-expected.json
@@ -1,0 +1,410 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "results"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "["
+  },
+  {
+    "type": "Punctuator",
+    "value": "]"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Identifier",
+    "value": "Promise"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "resolve"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Numeric",
+    "value": "42"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "then"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "value"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "=>"
+  },
+  {
+    "type": "Identifier",
+    "value": "value"
+  },
+  {
+    "type": "Punctuator",
+    "value": "+"
+  },
+  {
+    "type": "Numeric",
+    "value": "1"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "error"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "=>"
+  },
+  {
+    "type": "Identifier",
+    "value": "results"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "push"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "error"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Keyword",
+    "value": "finally"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "=>"
+  },
+  {
+    "type": "Identifier",
+    "value": "results"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "push"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "String",
+    "value": "'done'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "wrapper"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "handler"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "return"
+  },
+  {
+    "type": "Identifier",
+    "value": "handler"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Keyword",
+    "value": "finally"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "return"
+  },
+  {
+    "type": "Boolean",
+    "value": "true"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Identifier",
+    "value": "results"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "push"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "wrapper"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Keyword",
+    "value": "catch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "e"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "=>"
+  },
+  {
+    "type": "Identifier",
+    "value": "e"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Identifier",
+    "value": "results"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "push"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "wrapper"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Keyword",
+    "value": "finally"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  }
+]

--- a/tests/fixtures/test-0382-tokenize-loc-range-expected.json
+++ b/tests/fixtures/test-0382-tokenize-loc-range-expected.json
@@ -1,0 +1,1838 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      0,
+      5
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "results",
+    "range": [
+      6,
+      13
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      14,
+      15
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 14
+      },
+      "end": {
+        "line": 1,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "[",
+    "range": [
+      16,
+      17
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 16
+      },
+      "end": {
+        "line": 1,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]",
+    "range": [
+      17,
+      18
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 17
+      },
+      "end": {
+        "line": 1,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      18,
+      19
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 18
+      },
+      "end": {
+        "line": 1,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "Promise",
+    "range": [
+      21,
+      28
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      28,
+      29
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 7
+      },
+      "end": {
+        "line": 3,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "resolve",
+    "range": [
+      29,
+      36
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 8
+      },
+      "end": {
+        "line": 3,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      36,
+      37
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 15
+      },
+      "end": {
+        "line": 3,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "42",
+    "range": [
+      37,
+      39
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 16
+      },
+      "end": {
+        "line": 3,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      39,
+      40
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 18
+      },
+      "end": {
+        "line": 3,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      43,
+      44
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 2
+      },
+      "end": {
+        "line": 4,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "then",
+    "range": [
+      44,
+      48
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 3
+      },
+      "end": {
+        "line": 4,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      48,
+      49
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 7
+      },
+      "end": {
+        "line": 4,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      49,
+      50
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 8
+      },
+      "end": {
+        "line": 4,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "value",
+    "range": [
+      50,
+      55
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 9
+      },
+      "end": {
+        "line": 4,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      55,
+      56
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 14
+      },
+      "end": {
+        "line": 4,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=>",
+    "range": [
+      57,
+      59
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 16
+      },
+      "end": {
+        "line": 4,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "value",
+    "range": [
+      60,
+      65
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 19
+      },
+      "end": {
+        "line": 4,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "+",
+    "range": [
+      66,
+      67
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 25
+      },
+      "end": {
+        "line": 4,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "1",
+    "range": [
+      68,
+      69
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 27
+      },
+      "end": {
+        "line": 4,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      69,
+      70
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 28
+      },
+      "end": {
+        "line": 4,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      73,
+      74
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 2
+      },
+      "end": {
+        "line": 5,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      74,
+      79
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 3
+      },
+      "end": {
+        "line": 5,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      79,
+      80
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 8
+      },
+      "end": {
+        "line": 5,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      80,
+      81
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 9
+      },
+      "end": {
+        "line": 5,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "error",
+    "range": [
+      81,
+      86
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 10
+      },
+      "end": {
+        "line": 5,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      86,
+      87
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 15
+      },
+      "end": {
+        "line": 5,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=>",
+    "range": [
+      88,
+      90
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 17
+      },
+      "end": {
+        "line": 5,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "results",
+    "range": [
+      91,
+      98
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 20
+      },
+      "end": {
+        "line": 5,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      98,
+      99
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 27
+      },
+      "end": {
+        "line": 5,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "push",
+    "range": [
+      99,
+      103
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 28
+      },
+      "end": {
+        "line": 5,
+        "column": 32
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      103,
+      104
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 32
+      },
+      "end": {
+        "line": 5,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "error",
+    "range": [
+      104,
+      109
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 33
+      },
+      "end": {
+        "line": 5,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      109,
+      110
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 38
+      },
+      "end": {
+        "line": 5,
+        "column": 39
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      110,
+      111
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 39
+      },
+      "end": {
+        "line": 5,
+        "column": 40
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      114,
+      115
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 2
+      },
+      "end": {
+        "line": 6,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "finally",
+    "range": [
+      115,
+      122
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 3
+      },
+      "end": {
+        "line": 6,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      122,
+      123
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 10
+      },
+      "end": {
+        "line": 6,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      123,
+      124
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 11
+      },
+      "end": {
+        "line": 6,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      124,
+      125
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 12
+      },
+      "end": {
+        "line": 6,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=>",
+    "range": [
+      126,
+      128
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 14
+      },
+      "end": {
+        "line": 6,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "results",
+    "range": [
+      129,
+      136
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 17
+      },
+      "end": {
+        "line": 6,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      136,
+      137
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 24
+      },
+      "end": {
+        "line": 6,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "push",
+    "range": [
+      137,
+      141
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 25
+      },
+      "end": {
+        "line": 6,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      141,
+      142
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 29
+      },
+      "end": {
+        "line": 6,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'done'",
+    "range": [
+      142,
+      148
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 30
+      },
+      "end": {
+        "line": 6,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      148,
+      149
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 36
+      },
+      "end": {
+        "line": 6,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      149,
+      150
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 37
+      },
+      "end": {
+        "line": 6,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      150,
+      151
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 38
+      },
+      "end": {
+        "line": 6,
+        "column": 39
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      153,
+      158
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 0
+      },
+      "end": {
+        "line": 8,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "wrapper",
+    "range": [
+      159,
+      166
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 6
+      },
+      "end": {
+        "line": 8,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      167,
+      168
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 14
+      },
+      "end": {
+        "line": 8,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      169,
+      170
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 16
+      },
+      "end": {
+        "line": 8,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      173,
+      178
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 2
+      },
+      "end": {
+        "line": 9,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      178,
+      179
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 7
+      },
+      "end": {
+        "line": 9,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "handler",
+    "range": [
+      179,
+      186
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 8
+      },
+      "end": {
+        "line": 9,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      186,
+      187
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 15
+      },
+      "end": {
+        "line": 9,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      188,
+      189
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 17
+      },
+      "end": {
+        "line": 9,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "return",
+    "range": [
+      194,
+      200
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 4
+      },
+      "end": {
+        "line": 10,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "handler",
+    "range": [
+      201,
+      208
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 11
+      },
+      "end": {
+        "line": 10,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      208,
+      209
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 18
+      },
+      "end": {
+        "line": 10,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      212,
+      213
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 2
+      },
+      "end": {
+        "line": 11,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      213,
+      214
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 3
+      },
+      "end": {
+        "line": 11,
+        "column": 4
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "finally",
+    "range": [
+      217,
+      224
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 2
+      },
+      "end": {
+        "line": 12,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      224,
+      225
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 9
+      },
+      "end": {
+        "line": 12,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      225,
+      226
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 10
+      },
+      "end": {
+        "line": 12,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      227,
+      228
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 12
+      },
+      "end": {
+        "line": 12,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "return",
+    "range": [
+      233,
+      239
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 4
+      },
+      "end": {
+        "line": 13,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Boolean",
+    "value": "true",
+    "range": [
+      240,
+      244
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 11
+      },
+      "end": {
+        "line": 13,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      244,
+      245
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 15
+      },
+      "end": {
+        "line": 13,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      248,
+      249
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 2
+      },
+      "end": {
+        "line": 14,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      250,
+      251
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 0
+      },
+      "end": {
+        "line": 15,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      251,
+      252
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 1
+      },
+      "end": {
+        "line": 15,
+        "column": 2
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "results",
+    "range": [
+      254,
+      261
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 0
+      },
+      "end": {
+        "line": 17,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      261,
+      262
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 7
+      },
+      "end": {
+        "line": 17,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "push",
+    "range": [
+      262,
+      266
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 8
+      },
+      "end": {
+        "line": 17,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      266,
+      267
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 12
+      },
+      "end": {
+        "line": 17,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "wrapper",
+    "range": [
+      267,
+      274
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 13
+      },
+      "end": {
+        "line": 17,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      274,
+      275
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 20
+      },
+      "end": {
+        "line": 17,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "catch",
+    "range": [
+      275,
+      280
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 21
+      },
+      "end": {
+        "line": 17,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      280,
+      281
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 26
+      },
+      "end": {
+        "line": 17,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      281,
+      282
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 27
+      },
+      "end": {
+        "line": 17,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "e",
+    "range": [
+      282,
+      283
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 28
+      },
+      "end": {
+        "line": 17,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      283,
+      284
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 29
+      },
+      "end": {
+        "line": 17,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=>",
+    "range": [
+      285,
+      287
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 31
+      },
+      "end": {
+        "line": 17,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "e",
+    "range": [
+      288,
+      289
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 34
+      },
+      "end": {
+        "line": 17,
+        "column": 35
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      289,
+      290
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 35
+      },
+      "end": {
+        "line": 17,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      290,
+      291
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 36
+      },
+      "end": {
+        "line": 17,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      291,
+      292
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 37
+      },
+      "end": {
+        "line": 17,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "results",
+    "range": [
+      293,
+      300
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 0
+      },
+      "end": {
+        "line": 18,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      300,
+      301
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 7
+      },
+      "end": {
+        "line": 18,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "push",
+    "range": [
+      301,
+      305
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 8
+      },
+      "end": {
+        "line": 18,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      305,
+      306
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 12
+      },
+      "end": {
+        "line": 18,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "wrapper",
+    "range": [
+      306,
+      313
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 13
+      },
+      "end": {
+        "line": 18,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      313,
+      314
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 20
+      },
+      "end": {
+        "line": 18,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "finally",
+    "range": [
+      314,
+      321
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 21
+      },
+      "end": {
+        "line": 18,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      321,
+      322
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 28
+      },
+      "end": {
+        "line": 18,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      322,
+      323
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 29
+      },
+      "end": {
+        "line": 18,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      323,
+      324
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 30
+      },
+      "end": {
+        "line": 18,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      324,
+      325
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 31
+      },
+      "end": {
+        "line": 18,
+        "column": 32
+      }
+    }
+  }
+]

--- a/tests/fixtures/test-0382.js
+++ b/tests/fixtures/test-0382.js
@@ -1,0 +1,18 @@
+const results = [];
+
+Promise.resolve(42)
+  .then((value) => value + 1)
+  .catch((error) => results.push(error))
+  .finally(() => results.push('done'));
+
+const wrapper = {
+  catch(handler) {
+    return handler;
+  },
+  finally() {
+    return true;
+  }
+};
+
+results.push(wrapper.catch((e) => e));
+results.push(wrapper.finally());

--- a/tests/fixtures/test-0383-parse-expected.json
+++ b/tests/fixtures/test-0383-parse-expected.json
@@ -1,0 +1,353 @@
+{
+  "range": [
+    0,
+    91
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 3,
+      "column": 30
+    }
+  },
+  "type": "Program",
+  "body": [
+    {
+      "range": [
+        0,
+        26
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 26
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            6,
+            25
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 25
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              6,
+              8
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            },
+            "type": "Identifier",
+            "name": "re"
+          },
+          "init": {
+            "range": [
+              11,
+              25
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 11
+              },
+              "end": {
+                "line": 1,
+                "column": 25
+              }
+            },
+            "type": "Literal",
+            "value": {},
+            "raw": "/(\\d+)-(\\d+)/d",
+            "regex": {
+              "pattern": "(\\d+)-(\\d+)",
+              "flags": "d"
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        27,
+        60
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 33
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            33,
+            59
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 6
+            },
+            "end": {
+              "line": 2,
+              "column": 32
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              33,
+              38
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 11
+              }
+            },
+            "type": "Identifier",
+            "name": "match"
+          },
+          "init": {
+            "range": [
+              41,
+              59
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 14
+              },
+              "end": {
+                "line": 2,
+                "column": 32
+              }
+            },
+            "type": "CallExpression",
+            "callee": {
+              "range": [
+                41,
+                48
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 14
+                },
+                "end": {
+                  "line": 2,
+                  "column": 21
+                }
+              },
+              "type": "MemberExpression",
+              "computed": false,
+              "object": {
+                "range": [
+                  41,
+                  43
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 16
+                  }
+                },
+                "type": "Identifier",
+                "name": "re"
+              },
+              "property": {
+                "range": [
+                  44,
+                  48
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 21
+                  }
+                },
+                "type": "Identifier",
+                "name": "exec"
+              }
+            },
+            "arguments": [
+              {
+                "range": [
+                  49,
+                  58
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 22
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 31
+                  }
+                },
+                "type": "Literal",
+                "value": "123-456",
+                "raw": "'123-456'"
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        61,
+        91
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 30
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            67,
+            90
+          ],
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 6
+            },
+            "end": {
+              "line": 3,
+              "column": 29
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              67,
+              74
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 6
+              },
+              "end": {
+                "line": 3,
+                "column": 13
+              }
+            },
+            "type": "Identifier",
+            "name": "indices"
+          },
+          "init": {
+            "range": [
+              77,
+              90
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 16
+              },
+              "end": {
+                "line": 3,
+                "column": 29
+              }
+            },
+            "type": "MemberExpression",
+            "computed": false,
+            "object": {
+              "range": [
+                77,
+                82
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 16
+                },
+                "end": {
+                  "line": 3,
+                  "column": 21
+                }
+              },
+              "type": "Identifier",
+              "name": "match"
+            },
+            "property": {
+              "range": [
+                83,
+                90
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 22
+                },
+                "end": {
+                  "line": 3,
+                  "column": 29
+                }
+              },
+              "type": "Identifier",
+              "name": "indices"
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    }
+  ]
+}

--- a/tests/fixtures/test-0383-parse-expected.json
+++ b/tests/fixtures/test-0383-parse-expected.json
@@ -177,6 +177,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   41,
@@ -214,6 +215,7 @@
                 "name": "exec"
               }
             },
+            "optional": false,
             "arguments": [
               {
                 "range": [
@@ -308,6 +310,7 @@
             },
             "type": "MemberExpression",
             "computed": false,
+            "optional": false,
             "object": {
               "range": [
                 77,

--- a/tests/fixtures/test-0383-tokenize-expected.json
+++ b/tests/fixtures/test-0383-tokenize-expected.json
@@ -1,0 +1,94 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "re"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/(\\d+)-(\\d+)/d",
+    "regex": {
+      "pattern": "(\\d+)-(\\d+)",
+      "flags": "d"
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "match"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "re"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "exec"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "String",
+    "value": "'123-456'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "indices"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "match"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "indices"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  }
+]

--- a/tests/fixtures/test-0383-tokenize-loc-range-expected.json
+++ b/tests/fixtures/test-0383-tokenize-loc-range-expected.json
@@ -1,0 +1,402 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      0,
+      5
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "re",
+    "range": [
+      6,
+      8
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      9,
+      10
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 9
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/(\\d+)-(\\d+)/d",
+    "regex": {
+      "pattern": "(\\d+)-(\\d+)",
+      "flags": "d"
+    },
+    "range": [
+      11,
+      25
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      25,
+      26
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 25
+      },
+      "end": {
+        "line": 1,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      27,
+      32
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "match",
+    "range": [
+      33,
+      38
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 6
+      },
+      "end": {
+        "line": 2,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      39,
+      40
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 12
+      },
+      "end": {
+        "line": 2,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "re",
+    "range": [
+      41,
+      43
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 14
+      },
+      "end": {
+        "line": 2,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      43,
+      44
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 16
+      },
+      "end": {
+        "line": 2,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "exec",
+    "range": [
+      44,
+      48
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 17
+      },
+      "end": {
+        "line": 2,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      48,
+      49
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 21
+      },
+      "end": {
+        "line": 2,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'123-456'",
+    "range": [
+      49,
+      58
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 22
+      },
+      "end": {
+        "line": 2,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      58,
+      59
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 31
+      },
+      "end": {
+        "line": 2,
+        "column": 32
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      59,
+      60
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 32
+      },
+      "end": {
+        "line": 2,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      61,
+      66
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "indices",
+    "range": [
+      67,
+      74
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 6
+      },
+      "end": {
+        "line": 3,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      75,
+      76
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 14
+      },
+      "end": {
+        "line": 3,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "match",
+    "range": [
+      77,
+      82
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 16
+      },
+      "end": {
+        "line": 3,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      82,
+      83
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 21
+      },
+      "end": {
+        "line": 3,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "indices",
+    "range": [
+      83,
+      90
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 22
+      },
+      "end": {
+        "line": 3,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      90,
+      91
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 29
+      },
+      "end": {
+        "line": 3,
+        "column": 30
+      }
+    }
+  }
+]

--- a/tests/fixtures/test-0383.js
+++ b/tests/fixtures/test-0383.js
@@ -1,0 +1,3 @@
+const re = /(\d+)-(\d+)/d;
+const match = re.exec('123-456');
+const indices = match.indices;

--- a/tests/fixtures/test-0384-parse-expected.json
+++ b/tests/fixtures/test-0384-parse-expected.json
@@ -1,0 +1,244 @@
+{
+  "range": [
+    0,
+    68
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 29
+    }
+  },
+  "type": "Program",
+  "body": [
+    {
+      "range": [
+        0,
+        38
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 38
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            6,
+            37
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 37
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              6,
+              8
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            },
+            "type": "Identifier",
+            "name": "re"
+          },
+          "init": {
+            "range": [
+              11,
+              37
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 11
+              },
+              "end": {
+                "line": 1,
+                "column": 37
+              }
+            },
+            "type": "Literal",
+            "value": {},
+            "raw": "/[\\p{ASCII}&&\\p{Letter}]/v",
+            "regex": {
+              "pattern": "[\\p{ASCII}&&\\p{Letter}]",
+              "flags": "v"
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        39,
+        68
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 29
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            45,
+            67
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 6
+            },
+            "end": {
+              "line": 2,
+              "column": 28
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              45,
+              52
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            "type": "Identifier",
+            "name": "matched"
+          },
+          "init": {
+            "range": [
+              55,
+              67
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 16
+              },
+              "end": {
+                "line": 2,
+                "column": 28
+              }
+            },
+            "type": "CallExpression",
+            "callee": {
+              "range": [
+                55,
+                62
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 16
+                },
+                "end": {
+                  "line": 2,
+                  "column": 23
+                }
+              },
+              "type": "MemberExpression",
+              "computed": false,
+              "object": {
+                "range": [
+                  55,
+                  57
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 18
+                  }
+                },
+                "type": "Identifier",
+                "name": "re"
+              },
+              "property": {
+                "range": [
+                  58,
+                  62
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 19
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 23
+                  }
+                },
+                "type": "Identifier",
+                "name": "test"
+              }
+            },
+            "arguments": [
+              {
+                "range": [
+                  63,
+                  66
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 27
+                  }
+                },
+                "type": "Literal",
+                "value": "A",
+                "raw": "'A'"
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "const"
+    }
+  ]
+}

--- a/tests/fixtures/test-0384-parse-expected.json
+++ b/tests/fixtures/test-0384-parse-expected.json
@@ -177,6 +177,7 @@
               },
               "type": "MemberExpression",
               "computed": false,
+              "optional": false,
               "object": {
                 "range": [
                   55,
@@ -214,6 +215,7 @@
                 "name": "test"
               }
             },
+            "optional": false,
             "arguments": [
               {
                 "range": [

--- a/tests/fixtures/test-0384-tokenize-expected.json
+++ b/tests/fixtures/test-0384-tokenize-expected.json
@@ -1,0 +1,66 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "re"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/[\\p{ASCII}&&\\p{Letter}]/v",
+    "regex": {
+      "pattern": "[\\p{ASCII}&&\\p{Letter}]",
+      "flags": "v"
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "matched"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "re"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "test"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "String",
+    "value": "'A'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  }
+]

--- a/tests/fixtures/test-0384-tokenize-loc-range-expected.json
+++ b/tests/fixtures/test-0384-tokenize-loc-range-expected.json
@@ -1,0 +1,276 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      0,
+      5
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "re",
+    "range": [
+      6,
+      8
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      9,
+      10
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 9
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/[\\p{ASCII}&&\\p{Letter}]/v",
+    "regex": {
+      "pattern": "[\\p{ASCII}&&\\p{Letter}]",
+      "flags": "v"
+    },
+    "range": [
+      11,
+      37
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      37,
+      38
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 37
+      },
+      "end": {
+        "line": 1,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      39,
+      44
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "matched",
+    "range": [
+      45,
+      52
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 6
+      },
+      "end": {
+        "line": 2,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      53,
+      54
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 14
+      },
+      "end": {
+        "line": 2,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "re",
+    "range": [
+      55,
+      57
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 16
+      },
+      "end": {
+        "line": 2,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      57,
+      58
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 18
+      },
+      "end": {
+        "line": 2,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "test",
+    "range": [
+      58,
+      62
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 19
+      },
+      "end": {
+        "line": 2,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      62,
+      63
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 23
+      },
+      "end": {
+        "line": 2,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'A'",
+    "range": [
+      63,
+      66
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 24
+      },
+      "end": {
+        "line": 2,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      66,
+      67
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 27
+      },
+      "end": {
+        "line": 2,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      67,
+      68
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 28
+      },
+      "end": {
+        "line": 2,
+        "column": 29
+      }
+    }
+  }
+]

--- a/tests/fixtures/test-0384.js
+++ b/tests/fixtures/test-0384.js
@@ -1,0 +1,2 @@
+const re = /[\p{ASCII}&&\p{Letter}]/v;
+const matched = re.test('A');

--- a/tests/fixtures/test-0385-parse-expected.json
+++ b/tests/fixtures/test-0385-parse-expected.json
@@ -1,0 +1,5995 @@
+{
+  "range": [
+    0,
+    1174
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 38,
+      "column": 27
+    }
+  },
+  "type": "Program",
+  "body": [
+    {
+      "range": [
+        0,
+        62
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 62
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            6,
+            11
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 11
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              6,
+              7
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 1,
+                "column": 7
+              }
+            },
+            "type": "Identifier",
+            "name": "d"
+          },
+          "init": {
+            "range": [
+              10,
+              11
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 10
+              },
+              "end": {
+                "line": 1,
+                "column": 11
+              }
+            },
+            "type": "Literal",
+            "value": 8,
+            "raw": "8"
+          }
+        },
+        {
+          "range": [
+            13,
+            18
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 13
+            },
+            "end": {
+              "line": 1,
+              "column": 18
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              13,
+              14
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 13
+              },
+              "end": {
+                "line": 1,
+                "column": 14
+              }
+            },
+            "type": "Identifier",
+            "name": "g"
+          },
+          "init": {
+            "range": [
+              17,
+              18
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 17
+              },
+              "end": {
+                "line": 1,
+                "column": 18
+              }
+            },
+            "type": "Literal",
+            "value": 4,
+            "raw": "4"
+          }
+        },
+        {
+          "range": [
+            20,
+            25
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 20
+            },
+            "end": {
+              "line": 1,
+              "column": 25
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              20,
+              21
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 20
+              },
+              "end": {
+                "line": 1,
+                "column": 21
+              }
+            },
+            "type": "Identifier",
+            "name": "i"
+          },
+          "init": {
+            "range": [
+              24,
+              25
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 24
+              },
+              "end": {
+                "line": 1,
+                "column": 25
+              }
+            },
+            "type": "Literal",
+            "value": 2,
+            "raw": "2"
+          }
+        },
+        {
+          "range": [
+            27,
+            33
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 27
+            },
+            "end": {
+              "line": 1,
+              "column": 33
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              27,
+              28
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 27
+              },
+              "end": {
+                "line": 1,
+                "column": 28
+              }
+            },
+            "type": "Identifier",
+            "name": "m"
+          },
+          "init": {
+            "range": [
+              31,
+              33
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 31
+              },
+              "end": {
+                "line": 1,
+                "column": 33
+              }
+            },
+            "type": "Literal",
+            "value": 16,
+            "raw": "16"
+          }
+        },
+        {
+          "range": [
+            35,
+            40
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 35
+            },
+            "end": {
+              "line": 1,
+              "column": 40
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              35,
+              36
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 35
+              },
+              "end": {
+                "line": 1,
+                "column": 36
+              }
+            },
+            "type": "Identifier",
+            "name": "s"
+          },
+          "init": {
+            "range": [
+              39,
+              40
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 39
+              },
+              "end": {
+                "line": 1,
+                "column": 40
+              }
+            },
+            "type": "Literal",
+            "value": 3,
+            "raw": "3"
+          }
+        },
+        {
+          "range": [
+            42,
+            47
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 42
+            },
+            "end": {
+              "line": 1,
+              "column": 47
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              42,
+              43
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 42
+              },
+              "end": {
+                "line": 1,
+                "column": 43
+              }
+            },
+            "type": "Identifier",
+            "name": "u"
+          },
+          "init": {
+            "range": [
+              46,
+              47
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 46
+              },
+              "end": {
+                "line": 1,
+                "column": 47
+              }
+            },
+            "type": "Literal",
+            "value": 6,
+            "raw": "6"
+          }
+        },
+        {
+          "range": [
+            49,
+            54
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 49
+            },
+            "end": {
+              "line": 1,
+              "column": 54
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              49,
+              50
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 49
+              },
+              "end": {
+                "line": 1,
+                "column": 50
+              }
+            },
+            "type": "Identifier",
+            "name": "v"
+          },
+          "init": {
+            "range": [
+              53,
+              54
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 53
+              },
+              "end": {
+                "line": 1,
+                "column": 54
+              }
+            },
+            "type": "Literal",
+            "value": 9,
+            "raw": "9"
+          }
+        },
+        {
+          "range": [
+            56,
+            61
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 56
+            },
+            "end": {
+              "line": 1,
+              "column": 61
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              56,
+              57
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 56
+              },
+              "end": {
+                "line": 1,
+                "column": 57
+              }
+            },
+            "type": "Identifier",
+            "name": "y"
+          },
+          "init": {
+            "range": [
+              60,
+              61
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 60
+              },
+              "end": {
+                "line": 1,
+                "column": 61
+              }
+            },
+            "type": "Literal",
+            "value": 5,
+            "raw": "5"
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        63,
+        82
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 19
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            67,
+            73
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 4
+            },
+            "end": {
+              "line": 2,
+              "column": 10
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              67,
+              68
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 5
+              }
+            },
+            "type": "Identifier",
+            "name": "p"
+          },
+          "init": {
+            "range": [
+              71,
+              73
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 8
+              },
+              "end": {
+                "line": 2,
+                "column": 10
+              }
+            },
+            "type": "Literal",
+            "value": 10,
+            "raw": "10"
+          }
+        },
+        {
+          "range": [
+            75,
+            81
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 12
+            },
+            "end": {
+              "line": 2,
+              "column": 18
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              75,
+              76
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 12
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            "type": "Identifier",
+            "name": "q"
+          },
+          "init": {
+            "range": [
+              79,
+              81
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 16
+              },
+              "end": {
+                "line": 2,
+                "column": 18
+              }
+            },
+            "type": "Literal",
+            "value": 12,
+            "raw": "12"
+          }
+        }
+      ],
+      "kind": "let"
+    },
+    {
+      "range": [
+        84,
+        124
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 40
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            90,
+            99
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 6
+            },
+            "end": {
+              "line": 4,
+              "column": 15
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              90,
+              91
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 6
+              },
+              "end": {
+                "line": 4,
+                "column": 7
+              }
+            },
+            "type": "Identifier",
+            "name": "a"
+          },
+          "init": {
+            "range": [
+              94,
+              99
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 10
+              },
+              "end": {
+                "line": 4,
+                "column": 15
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "/",
+            "left": {
+              "range": [
+                94,
+                97
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 10
+                },
+                "end": {
+                  "line": 4,
+                  "column": 13
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  94,
+                  95
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 11
+                  }
+                },
+                "type": "Identifier",
+                "name": "d"
+              },
+              "right": {
+                "range": [
+                  96,
+                  97
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 13
+                  }
+                },
+                "type": "Identifier",
+                "name": "g"
+              }
+            },
+            "right": {
+              "range": [
+                98,
+                99
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 14
+                },
+                "end": {
+                  "line": 4,
+                  "column": 15
+                }
+              },
+              "type": "Identifier",
+              "name": "i"
+            }
+          }
+        },
+        {
+          "range": [
+            101,
+            110
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 17
+            },
+            "end": {
+              "line": 4,
+              "column": 26
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              101,
+              102
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 17
+              },
+              "end": {
+                "line": 4,
+                "column": 18
+              }
+            },
+            "type": "Identifier",
+            "name": "b"
+          },
+          "init": {
+            "range": [
+              105,
+              110
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 21
+              },
+              "end": {
+                "line": 4,
+                "column": 26
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "/",
+            "left": {
+              "range": [
+                105,
+                108
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 21
+                },
+                "end": {
+                  "line": 4,
+                  "column": 24
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  105,
+                  106
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 22
+                  }
+                },
+                "type": "Identifier",
+                "name": "m"
+              },
+              "right": {
+                "range": [
+                  107,
+                  108
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 23
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 24
+                  }
+                },
+                "type": "Identifier",
+                "name": "s"
+              }
+            },
+            "right": {
+              "range": [
+                109,
+                110
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 25
+                },
+                "end": {
+                  "line": 4,
+                  "column": 26
+                }
+              },
+              "type": "Identifier",
+              "name": "u"
+            }
+          }
+        },
+        {
+          "range": [
+            112,
+            123
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 28
+            },
+            "end": {
+              "line": 4,
+              "column": 39
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              112,
+              113
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 28
+              },
+              "end": {
+                "line": 4,
+                "column": 29
+              }
+            },
+            "type": "Identifier",
+            "name": "c"
+          },
+          "init": {
+            "range": [
+              116,
+              123
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 32
+              },
+              "end": {
+                "line": 4,
+                "column": 39
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "/",
+            "left": {
+              "range": [
+                116,
+                121
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 32
+                },
+                "end": {
+                  "line": 4,
+                  "column": 37
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  116,
+                  119
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 32
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 35
+                  }
+                },
+                "type": "BinaryExpression",
+                "operator": "/",
+                "left": {
+                  "range": [
+                    116,
+                    117
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 32
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 33
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "v"
+                },
+                "right": {
+                  "range": [
+                    118,
+                    119
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 4,
+                      "column": 34
+                    },
+                    "end": {
+                      "line": 4,
+                      "column": 35
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "y"
+                }
+              },
+              "right": {
+                "range": [
+                  120,
+                  121
+                ],
+                "loc": {
+                  "start": {
+                    "line": 4,
+                    "column": 36
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 37
+                  }
+                },
+                "type": "Identifier",
+                "name": "d"
+              }
+            },
+            "right": {
+              "range": [
+                122,
+                123
+              ],
+              "loc": {
+                "start": {
+                  "line": 4,
+                  "column": 38
+                },
+                "end": {
+                  "line": 4,
+                  "column": 39
+                }
+              },
+              "type": "Identifier",
+              "name": "g"
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        125,
+        180
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 0
+        },
+        "end": {
+          "line": 5,
+          "column": 55
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            131,
+            142
+          ],
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 6
+            },
+            "end": {
+              "line": 5,
+              "column": 17
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              131,
+              132
+            ],
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 6
+              },
+              "end": {
+                "line": 5,
+                "column": 7
+              }
+            },
+            "type": "Identifier",
+            "name": "e"
+          },
+          "init": {
+            "range": [
+              135,
+              142
+            ],
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 10
+              },
+              "end": {
+                "line": 5,
+                "column": 17
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "/",
+            "left": {
+              "range": [
+                135,
+                140
+              ],
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 10
+                },
+                "end": {
+                  "line": 5,
+                  "column": 15
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  136,
+                  137
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 12
+                  }
+                },
+                "type": "Identifier",
+                "name": "d"
+              },
+              "right": {
+                "range": [
+                  139,
+                  140
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 15
+                  }
+                },
+                "type": "Identifier",
+                "name": "g"
+              }
+            },
+            "right": {
+              "range": [
+                141,
+                142
+              ],
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 16
+                },
+                "end": {
+                  "line": 5,
+                  "column": 17
+                }
+              },
+              "type": "Identifier",
+              "name": "i"
+            }
+          }
+        },
+        {
+          "range": [
+            144,
+            158
+          ],
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 19
+            },
+            "end": {
+              "line": 5,
+              "column": 33
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              144,
+              145
+            ],
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 19
+              },
+              "end": {
+                "line": 5,
+                "column": 20
+              }
+            },
+            "type": "Identifier",
+            "name": "f"
+          },
+          "init": {
+            "range": [
+              148,
+              158
+            ],
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 23
+              },
+              "end": {
+                "line": 5,
+                "column": 33
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "/",
+            "left": {
+              "range": [
+                148,
+                156
+              ],
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 23
+                },
+                "end": {
+                  "line": 5,
+                  "column": 31
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  148,
+                  154
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 23
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 29
+                  }
+                },
+                "type": "MemberExpression",
+                "computed": true,
+                "optional": false,
+                "object": {
+                  "range": [
+                    148,
+                    151
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 23
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 26
+                    }
+                  },
+                  "type": "ArrayExpression",
+                  "elements": [
+                    {
+                      "range": [
+                        149,
+                        150
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 5,
+                          "column": 24
+                        },
+                        "end": {
+                          "line": 5,
+                          "column": 25
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "m"
+                    }
+                  ]
+                },
+                "property": {
+                  "range": [
+                    152,
+                    153
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 27
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 28
+                    }
+                  },
+                  "type": "Literal",
+                  "value": 0,
+                  "raw": "0"
+                }
+              },
+              "right": {
+                "range": [
+                  155,
+                  156
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 30
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 31
+                  }
+                },
+                "type": "Identifier",
+                "name": "s"
+              }
+            },
+            "right": {
+              "range": [
+                157,
+                158
+              ],
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 32
+                },
+                "end": {
+                  "line": 5,
+                  "column": 33
+                }
+              },
+              "type": "Identifier",
+              "name": "u"
+            }
+          }
+        },
+        {
+          "range": [
+            160,
+            179
+          ],
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 35
+            },
+            "end": {
+              "line": 5,
+              "column": 54
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              160,
+              161
+            ],
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 35
+              },
+              "end": {
+                "line": 5,
+                "column": 36
+              }
+            },
+            "type": "Identifier",
+            "name": "h"
+          },
+          "init": {
+            "range": [
+              164,
+              179
+            ],
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 39
+              },
+              "end": {
+                "line": 5,
+                "column": 54
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "/",
+            "left": {
+              "range": [
+                164,
+                177
+              ],
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 39
+                },
+                "end": {
+                  "line": 5,
+                  "column": 52
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  164,
+                  175
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 39
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 50
+                  }
+                },
+                "type": "CallExpression",
+                "callee": {
+                  "range": [
+                    164,
+                    173
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 5,
+                      "column": 39
+                    },
+                    "end": {
+                      "line": 5,
+                      "column": 48
+                    }
+                  },
+                  "type": "MemberExpression",
+                  "computed": false,
+                  "optional": false,
+                  "object": {
+                    "range": [
+                      164,
+                      165
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 39
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 40
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "i"
+                  },
+                  "property": {
+                    "range": [
+                      166,
+                      173
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 5,
+                        "column": 41
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 48
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "valueOf"
+                  }
+                },
+                "optional": false,
+                "arguments": []
+              },
+              "right": {
+                "range": [
+                  176,
+                  177
+                ],
+                "loc": {
+                  "start": {
+                    "line": 5,
+                    "column": 51
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 52
+                  }
+                },
+                "type": "Identifier",
+                "name": "g"
+              }
+            },
+            "right": {
+              "range": [
+                178,
+                179
+              ],
+              "loc": {
+                "start": {
+                  "line": 5,
+                  "column": 53
+                },
+                "end": {
+                  "line": 5,
+                  "column": 54
+                }
+              },
+              "type": "Identifier",
+              "name": "i"
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        244,
+        301
+      ],
+      "loc": {
+        "start": {
+          "line": 8,
+          "column": 0
+        },
+        "end": {
+          "line": 8,
+          "column": 57
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            250,
+            261
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 6
+            },
+            "end": {
+              "line": 8,
+              "column": 17
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              250,
+              251
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 6
+              },
+              "end": {
+                "line": 8,
+                "column": 7
+              }
+            },
+            "type": "Identifier",
+            "name": "j"
+          },
+          "init": {
+            "range": [
+              254,
+              261
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 10
+              },
+              "end": {
+                "line": 8,
+                "column": 17
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "/",
+            "left": {
+              "range": [
+                254,
+                259
+              ],
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 10
+                },
+                "end": {
+                  "line": 8,
+                  "column": 15
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  254,
+                  257
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 13
+                  }
+                },
+                "type": "UpdateExpression",
+                "operator": "--",
+                "argument": {
+                  "range": [
+                    256,
+                    257
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 13
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "p"
+                },
+                "prefix": true
+              },
+              "right": {
+                "range": [
+                  258,
+                  259
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 15
+                  }
+                },
+                "type": "Identifier",
+                "name": "s"
+              }
+            },
+            "right": {
+              "range": [
+                260,
+                261
+              ],
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 16
+                },
+                "end": {
+                  "line": 8,
+                  "column": 17
+                }
+              },
+              "type": "Identifier",
+              "name": "u"
+            }
+          }
+        },
+        {
+          "range": [
+            263,
+            274
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 19
+            },
+            "end": {
+              "line": 8,
+              "column": 30
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              263,
+              264
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 19
+              },
+              "end": {
+                "line": 8,
+                "column": 20
+              }
+            },
+            "type": "Identifier",
+            "name": "k"
+          },
+          "init": {
+            "range": [
+              267,
+              274
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 23
+              },
+              "end": {
+                "line": 8,
+                "column": 30
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "/",
+            "left": {
+              "range": [
+                267,
+                272
+              ],
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 23
+                },
+                "end": {
+                  "line": 8,
+                  "column": 28
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  267,
+                  270
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 23
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 26
+                  }
+                },
+                "type": "UpdateExpression",
+                "operator": "++",
+                "argument": {
+                  "range": [
+                    269,
+                    270
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 25
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 26
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "q"
+                },
+                "prefix": true
+              },
+              "right": {
+                "range": [
+                  271,
+                  272
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 28
+                  }
+                },
+                "type": "Identifier",
+                "name": "y"
+              }
+            },
+            "right": {
+              "range": [
+                273,
+                274
+              ],
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 29
+                },
+                "end": {
+                  "line": 8,
+                  "column": 30
+                }
+              },
+              "type": "Identifier",
+              "name": "d"
+            }
+          }
+        },
+        {
+          "range": [
+            276,
+            287
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 32
+            },
+            "end": {
+              "line": 8,
+              "column": 43
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              276,
+              277
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 32
+              },
+              "end": {
+                "line": 8,
+                "column": 33
+              }
+            },
+            "type": "Identifier",
+            "name": "l"
+          },
+          "init": {
+            "range": [
+              280,
+              287
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 36
+              },
+              "end": {
+                "line": 8,
+                "column": 43
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "/",
+            "left": {
+              "range": [
+                280,
+                285
+              ],
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 36
+                },
+                "end": {
+                  "line": 8,
+                  "column": 41
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  280,
+                  283
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 36
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 39
+                  }
+                },
+                "type": "UpdateExpression",
+                "operator": "++",
+                "argument": {
+                  "range": [
+                    280,
+                    281
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 36
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 37
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "p"
+                },
+                "prefix": false
+              },
+              "right": {
+                "range": [
+                  284,
+                  285
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 40
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 41
+                  }
+                },
+                "type": "Identifier",
+                "name": "g"
+              }
+            },
+            "right": {
+              "range": [
+                286,
+                287
+              ],
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 42
+                },
+                "end": {
+                  "line": 8,
+                  "column": 43
+                }
+              },
+              "type": "Identifier",
+              "name": "i"
+            }
+          }
+        },
+        {
+          "range": [
+            289,
+            300
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 45
+            },
+            "end": {
+              "line": 8,
+              "column": 56
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              289,
+              290
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 45
+              },
+              "end": {
+                "line": 8,
+                "column": 46
+              }
+            },
+            "type": "Identifier",
+            "name": "x"
+          },
+          "init": {
+            "range": [
+              293,
+              300
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 49
+              },
+              "end": {
+                "line": 8,
+                "column": 56
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "/",
+            "left": {
+              "range": [
+                293,
+                298
+              ],
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 49
+                },
+                "end": {
+                  "line": 8,
+                  "column": 54
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  293,
+                  296
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 49
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 52
+                  }
+                },
+                "type": "UpdateExpression",
+                "operator": "--",
+                "argument": {
+                  "range": [
+                    293,
+                    294
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 49
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 50
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "q"
+                },
+                "prefix": false
+              },
+              "right": {
+                "range": [
+                  297,
+                  298
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 53
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 54
+                  }
+                },
+                "type": "Identifier",
+                "name": "s"
+              }
+            },
+            "right": {
+              "range": [
+                299,
+                300
+              ],
+              "loc": {
+                "start": {
+                  "line": 8,
+                  "column": 55
+                },
+                "end": {
+                  "line": 8,
+                  "column": 56
+                }
+              },
+              "type": "Identifier",
+              "name": "u"
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        303,
+        322
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 19
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            307,
+            313
+          ],
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 4
+            },
+            "end": {
+              "line": 10,
+              "column": 10
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              307,
+              309
+            ],
+            "loc": {
+              "start": {
+                "line": 10,
+                "column": 4
+              },
+              "end": {
+                "line": 10,
+                "column": 6
+              }
+            },
+            "type": "Identifier",
+            "name": "n1"
+          },
+          "init": {
+            "range": [
+              312,
+              313
+            ],
+            "loc": {
+              "start": {
+                "line": 10,
+                "column": 9
+              },
+              "end": {
+                "line": 10,
+                "column": 10
+              }
+            },
+            "type": "Literal",
+            "value": 1,
+            "raw": "1"
+          }
+        },
+        {
+          "range": [
+            315,
+            321
+          ],
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 12
+            },
+            "end": {
+              "line": 10,
+              "column": 18
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              315,
+              317
+            ],
+            "loc": {
+              "start": {
+                "line": 10,
+                "column": 12
+              },
+              "end": {
+                "line": 10,
+                "column": 14
+              }
+            },
+            "type": "Identifier",
+            "name": "n2"
+          },
+          "init": {
+            "range": [
+              320,
+              321
+            ],
+            "loc": {
+              "start": {
+                "line": 10,
+                "column": 17
+              },
+              "end": {
+                "line": 10,
+                "column": 18
+              }
+            },
+            "type": "Literal",
+            "value": 9,
+            "raw": "9"
+          }
+        }
+      ],
+      "kind": "let"
+    },
+    {
+      "range": [
+        440,
+        489
+      ],
+      "loc": {
+        "start": {
+          "line": 13,
+          "column": 0
+        },
+        "end": {
+          "line": 13,
+          "column": 49
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            446,
+            466
+          ],
+          "loc": {
+            "start": {
+              "line": 13,
+              "column": 6
+            },
+            "end": {
+              "line": 13,
+              "column": 26
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              446,
+              448
+            ],
+            "loc": {
+              "start": {
+                "line": 13,
+                "column": 6
+              },
+              "end": {
+                "line": 13,
+                "column": 8
+              }
+            },
+            "type": "Identifier",
+            "name": "o1"
+          },
+          "init": {
+            "range": [
+              451,
+              466
+            ],
+            "loc": {
+              "start": {
+                "line": 13,
+                "column": 11
+              },
+              "end": {
+                "line": 13,
+                "column": 26
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "+",
+            "left": {
+              "range": [
+                451,
+                455
+              ],
+              "loc": {
+                "start": {
+                  "line": 13,
+                  "column": 11
+                },
+                "end": {
+                  "line": 13,
+                  "column": 15
+                }
+              },
+              "type": "UpdateExpression",
+              "operator": "++",
+              "argument": {
+                "range": [
+                  451,
+                  453
+                ],
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 13
+                  }
+                },
+                "type": "Identifier",
+                "name": "n1"
+              },
+              "prefix": false
+            },
+            "right": {
+              "range": [
+                456,
+                466
+              ],
+              "loc": {
+                "start": {
+                  "line": 13,
+                  "column": 16
+                },
+                "end": {
+                  "line": 13,
+                  "column": 26
+                }
+              },
+              "type": "MemberExpression",
+              "computed": false,
+              "optional": false,
+              "object": {
+                "range": [
+                  456,
+                  459
+                ],
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 19
+                  }
+                },
+                "type": "Literal",
+                "value": {},
+                "raw": "/g/",
+                "regex": {
+                  "pattern": "g",
+                  "flags": ""
+                }
+              },
+              "property": {
+                "range": [
+                  460,
+                  466
+                ],
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 26
+                  }
+                },
+                "type": "Identifier",
+                "name": "source"
+              }
+            }
+          }
+        },
+        {
+          "range": [
+            468,
+            488
+          ],
+          "loc": {
+            "start": {
+              "line": 13,
+              "column": 28
+            },
+            "end": {
+              "line": 13,
+              "column": 48
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              468,
+              470
+            ],
+            "loc": {
+              "start": {
+                "line": 13,
+                "column": 28
+              },
+              "end": {
+                "line": 13,
+                "column": 30
+              }
+            },
+            "type": "Identifier",
+            "name": "o2"
+          },
+          "init": {
+            "range": [
+              473,
+              488
+            ],
+            "loc": {
+              "start": {
+                "line": 13,
+                "column": 33
+              },
+              "end": {
+                "line": 13,
+                "column": 48
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "-",
+            "left": {
+              "range": [
+                473,
+                477
+              ],
+              "loc": {
+                "start": {
+                  "line": 13,
+                  "column": 33
+                },
+                "end": {
+                  "line": 13,
+                  "column": 37
+                }
+              },
+              "type": "UpdateExpression",
+              "operator": "--",
+              "argument": {
+                "range": [
+                  473,
+                  475
+                ],
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 33
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 35
+                  }
+                },
+                "type": "Identifier",
+                "name": "n2"
+              },
+              "prefix": false
+            },
+            "right": {
+              "range": [
+                478,
+                488
+              ],
+              "loc": {
+                "start": {
+                  "line": 13,
+                  "column": 38
+                },
+                "end": {
+                  "line": 13,
+                  "column": 48
+                }
+              },
+              "type": "MemberExpression",
+              "computed": false,
+              "optional": false,
+              "object": {
+                "range": [
+                  478,
+                  481
+                ],
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 38
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 41
+                  }
+                },
+                "type": "Literal",
+                "value": {},
+                "raw": "/s/",
+                "regex": {
+                  "pattern": "s",
+                  "flags": ""
+                }
+              },
+              "property": {
+                "range": [
+                  482,
+                  488
+                ],
+                "loc": {
+                  "start": {
+                    "line": 13,
+                    "column": 42
+                  },
+                  "end": {
+                    "line": 13,
+                    "column": 48
+                  }
+                },
+                "type": "Identifier",
+                "name": "source"
+              }
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        491,
+        508
+      ],
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 0
+        },
+        "end": {
+          "line": 15,
+          "column": 17
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            497,
+            507
+          ],
+          "loc": {
+            "start": {
+              "line": 15,
+              "column": 6
+            },
+            "end": {
+              "line": 15,
+              "column": 16
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              497,
+              500
+            ],
+            "loc": {
+              "start": {
+                "line": 15,
+                "column": 6
+              },
+              "end": {
+                "line": 15,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "re1"
+          },
+          "init": {
+            "range": [
+              503,
+              507
+            ],
+            "loc": {
+              "start": {
+                "line": 15,
+                "column": 12
+              },
+              "end": {
+                "line": 15,
+                "column": 16
+              }
+            },
+            "type": "Literal",
+            "value": {},
+            "raw": "/=/g",
+            "regex": {
+              "pattern": "=",
+              "flags": "g"
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        509,
+        536
+      ],
+      "loc": {
+        "start": {
+          "line": 16,
+          "column": 0
+        },
+        "end": {
+          "line": 16,
+          "column": 27
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            515,
+            535
+          ],
+          "loc": {
+            "start": {
+              "line": 16,
+              "column": 6
+            },
+            "end": {
+              "line": 16,
+              "column": 26
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              515,
+              518
+            ],
+            "loc": {
+              "start": {
+                "line": 16,
+                "column": 6
+              },
+              "end": {
+                "line": 16,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "re2"
+          },
+          "init": {
+            "range": [
+              521,
+              535
+            ],
+            "loc": {
+              "start": {
+                "line": 16,
+                "column": 12
+              },
+              "end": {
+                "line": 16,
+                "column": 26
+              }
+            },
+            "type": "Literal",
+            "value": {},
+            "raw": "/a\\/b\\/c/gimsu",
+            "regex": {
+              "pattern": "a\\/b\\/c",
+              "flags": "gimsu"
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        537,
+        572
+      ],
+      "loc": {
+        "start": {
+          "line": 17,
+          "column": 0
+        },
+        "end": {
+          "line": 17,
+          "column": 35
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            543,
+            571
+          ],
+          "loc": {
+            "start": {
+              "line": 17,
+              "column": 6
+            },
+            "end": {
+              "line": 17,
+              "column": 34
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              543,
+              546
+            ],
+            "loc": {
+              "start": {
+                "line": 17,
+                "column": 6
+              },
+              "end": {
+                "line": 17,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "re3"
+          },
+          "init": {
+            "range": [
+              549,
+              571
+            ],
+            "loc": {
+              "start": {
+                "line": 17,
+                "column": 12
+              },
+              "end": {
+                "line": 17,
+                "column": 34
+              }
+            },
+            "type": "ConditionalExpression",
+            "test": {
+              "range": [
+                549,
+                554
+              ],
+              "loc": {
+                "start": {
+                  "line": 17,
+                  "column": 12
+                },
+                "end": {
+                  "line": 17,
+                  "column": 17
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": ">",
+              "left": {
+                "range": [
+                  549,
+                  550
+                ],
+                "loc": {
+                  "start": {
+                    "line": 17,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 17,
+                    "column": 13
+                  }
+                },
+                "type": "Identifier",
+                "name": "i"
+              },
+              "right": {
+                "range": [
+                  553,
+                  554
+                ],
+                "loc": {
+                  "start": {
+                    "line": 17,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 17,
+                    "column": 17
+                  }
+                },
+                "type": "Literal",
+                "value": 0,
+                "raw": "0"
+              }
+            },
+            "consequent": {
+              "range": [
+                557,
+                564
+              ],
+              "loc": {
+                "start": {
+                  "line": 17,
+                  "column": 20
+                },
+                "end": {
+                  "line": 17,
+                  "column": 27
+                }
+              },
+              "type": "Literal",
+              "value": {},
+              "raw": "/^\\d+$/",
+              "regex": {
+                "pattern": "^\\d+$",
+                "flags": ""
+              }
+            },
+            "alternate": {
+              "range": [
+                567,
+                571
+              ],
+              "loc": {
+                "start": {
+                  "line": 17,
+                  "column": 30
+                },
+                "end": {
+                  "line": 17,
+                  "column": 34
+                }
+              },
+              "type": "Literal",
+              "value": {},
+              "raw": "/x/y",
+              "regex": {
+                "pattern": "x",
+                "flags": "y"
+              }
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        573,
+        603
+      ],
+      "loc": {
+        "start": {
+          "line": 18,
+          "column": 0
+        },
+        "end": {
+          "line": 18,
+          "column": 30
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            579,
+            602
+          ],
+          "loc": {
+            "start": {
+              "line": 18,
+              "column": 6
+            },
+            "end": {
+              "line": 18,
+              "column": 29
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              579,
+              582
+            ],
+            "loc": {
+              "start": {
+                "line": 18,
+                "column": 6
+              },
+              "end": {
+                "line": 18,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "re4"
+          },
+          "init": {
+            "range": [
+              585,
+              602
+            ],
+            "loc": {
+              "start": {
+                "line": 18,
+                "column": 12
+              },
+              "end": {
+                "line": 18,
+                "column": 29
+              }
+            },
+            "type": "ArrayExpression",
+            "elements": [
+              {
+                "range": [
+                  586,
+                  589
+                ],
+                "loc": {
+                  "start": {
+                    "line": 18,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 18,
+                    "column": 16
+                  }
+                },
+                "type": "Literal",
+                "value": {},
+                "raw": "/g/",
+                "regex": {
+                  "pattern": "g",
+                  "flags": ""
+                }
+              },
+              {
+                "range": [
+                  591,
+                  595
+                ],
+                "loc": {
+                  "start": {
+                    "line": 18,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 18,
+                    "column": 22
+                  }
+                },
+                "type": "Literal",
+                "value": {},
+                "raw": "/i/m",
+                "regex": {
+                  "pattern": "i",
+                  "flags": "m"
+                }
+              },
+              {
+                "range": [
+                  597,
+                  601
+                ],
+                "loc": {
+                  "start": {
+                    "line": 18,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 18,
+                    "column": 28
+                  }
+                },
+                "type": "Literal",
+                "value": {},
+                "raw": "/s/u",
+                "regex": {
+                  "pattern": "s",
+                  "flags": "u"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        604,
+        637
+      ],
+      "loc": {
+        "start": {
+          "line": 19,
+          "column": 0
+        },
+        "end": {
+          "line": 19,
+          "column": 33
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            610,
+            636
+          ],
+          "loc": {
+            "start": {
+              "line": 19,
+              "column": 6
+            },
+            "end": {
+              "line": 19,
+              "column": 32
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              610,
+              613
+            ],
+            "loc": {
+              "start": {
+                "line": 19,
+                "column": 6
+              },
+              "end": {
+                "line": 19,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "re5"
+          },
+          "init": {
+            "range": [
+              616,
+              636
+            ],
+            "loc": {
+              "start": {
+                "line": 19,
+                "column": 12
+              },
+              "end": {
+                "line": 19,
+                "column": 32
+              }
+            },
+            "type": "ObjectExpression",
+            "properties": [
+              {
+                "range": [
+                  618,
+                  624
+                ],
+                "loc": {
+                  "start": {
+                    "line": 19,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 19,
+                    "column": 20
+                  }
+                },
+                "type": "Property",
+                "key": {
+                  "range": [
+                    618,
+                    619
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 19,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 19,
+                      "column": 15
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "p"
+                },
+                "computed": false,
+                "value": {
+                  "range": [
+                    621,
+                    624
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 19,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 19,
+                      "column": 20
+                    }
+                  },
+                  "type": "Literal",
+                  "value": {},
+                  "raw": "/v/",
+                  "regex": {
+                    "pattern": "v",
+                    "flags": ""
+                  }
+                },
+                "kind": "init",
+                "method": false,
+                "shorthand": false
+              },
+              {
+                "range": [
+                  626,
+                  634
+                ],
+                "loc": {
+                  "start": {
+                    "line": 19,
+                    "column": 22
+                  },
+                  "end": {
+                    "line": 19,
+                    "column": 30
+                  }
+                },
+                "type": "Property",
+                "key": {
+                  "range": [
+                    626,
+                    627
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 19,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 19,
+                      "column": 23
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "q"
+                },
+                "computed": false,
+                "value": {
+                  "range": [
+                    629,
+                    634
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 19,
+                      "column": 25
+                    },
+                    "end": {
+                      "line": 19,
+                      "column": 30
+                    }
+                  },
+                  "type": "BinaryExpression",
+                  "operator": "/",
+                  "left": {
+                    "range": [
+                      629,
+                      632
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 19,
+                        "column": 25
+                      },
+                      "end": {
+                        "line": 19,
+                        "column": 28
+                      }
+                    },
+                    "type": "BinaryExpression",
+                    "operator": "/",
+                    "left": {
+                      "range": [
+                        629,
+                        630
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 19,
+                          "column": 25
+                        },
+                        "end": {
+                          "line": 19,
+                          "column": 26
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "d"
+                    },
+                    "right": {
+                      "range": [
+                        631,
+                        632
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 19,
+                          "column": 27
+                        },
+                        "end": {
+                          "line": 19,
+                          "column": 28
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "g"
+                    }
+                  },
+                  "right": {
+                    "range": [
+                      633,
+                      634
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 19,
+                        "column": 29
+                      },
+                      "end": {
+                        "line": 19,
+                        "column": 30
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "i"
+                  }
+                },
+                "kind": "init",
+                "method": false,
+                "shorthand": false
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        638,
+        685
+      ],
+      "loc": {
+        "start": {
+          "line": 20,
+          "column": 0
+        },
+        "end": {
+          "line": 20,
+          "column": 47
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            644,
+            684
+          ],
+          "loc": {
+            "start": {
+              "line": 20,
+              "column": 6
+            },
+            "end": {
+              "line": 20,
+              "column": 46
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              644,
+              645
+            ],
+            "loc": {
+              "start": {
+                "line": 20,
+                "column": 6
+              },
+              "end": {
+                "line": 20,
+                "column": 7
+              }
+            },
+            "type": "Identifier",
+            "name": "w"
+          },
+          "init": {
+            "range": [
+              648,
+              684
+            ],
+            "loc": {
+              "start": {
+                "line": 20,
+                "column": 10
+              },
+              "end": {
+                "line": 20,
+                "column": 46
+              }
+            },
+            "type": "ConditionalExpression",
+            "test": {
+              "range": [
+                648,
+                672
+              ],
+              "loc": {
+                "start": {
+                  "line": 20,
+                  "column": 10
+                },
+                "end": {
+                  "line": 20,
+                  "column": 34
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "===",
+              "left": {
+                "range": [
+                  648,
+                  659
+                ],
+                "loc": {
+                  "start": {
+                    "line": 20,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 20,
+                    "column": 21
+                  }
+                },
+                "type": "UnaryExpression",
+                "operator": "typeof",
+                "argument": {
+                  "range": [
+                    655,
+                    659
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 20,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 20,
+                      "column": 21
+                    }
+                  },
+                  "type": "Literal",
+                  "value": {},
+                  "raw": "/re/",
+                  "regex": {
+                    "pattern": "re",
+                    "flags": ""
+                  }
+                },
+                "prefix": true
+              },
+              "right": {
+                "range": [
+                  664,
+                  672
+                ],
+                "loc": {
+                  "start": {
+                    "line": 20,
+                    "column": 26
+                  },
+                  "end": {
+                    "line": 20,
+                    "column": 34
+                  }
+                },
+                "type": "Literal",
+                "value": "object",
+                "raw": "'object'"
+              }
+            },
+            "consequent": {
+              "range": [
+                675,
+                678
+              ],
+              "loc": {
+                "start": {
+                  "line": 20,
+                  "column": 37
+                },
+                "end": {
+                  "line": 20,
+                  "column": 40
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  675,
+                  676
+                ],
+                "loc": {
+                  "start": {
+                    "line": 20,
+                    "column": 37
+                  },
+                  "end": {
+                    "line": 20,
+                    "column": 38
+                  }
+                },
+                "type": "Identifier",
+                "name": "d"
+              },
+              "right": {
+                "range": [
+                  677,
+                  678
+                ],
+                "loc": {
+                  "start": {
+                    "line": 20,
+                    "column": 39
+                  },
+                  "end": {
+                    "line": 20,
+                    "column": 40
+                  }
+                },
+                "type": "Identifier",
+                "name": "g"
+              }
+            },
+            "alternate": {
+              "range": [
+                681,
+                684
+              ],
+              "loc": {
+                "start": {
+                  "line": 20,
+                  "column": 43
+                },
+                "end": {
+                  "line": 20,
+                  "column": 46
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  681,
+                  682
+                ],
+                "loc": {
+                  "start": {
+                    "line": 20,
+                    "column": 43
+                  },
+                  "end": {
+                    "line": 20,
+                    "column": 44
+                  }
+                },
+                "type": "Identifier",
+                "name": "g"
+              },
+              "right": {
+                "range": [
+                  683,
+                  684
+                ],
+                "loc": {
+                  "start": {
+                    "line": 20,
+                    "column": 45
+                  },
+                  "end": {
+                    "line": 20,
+                    "column": 46
+                  }
+                },
+                "type": "Identifier",
+                "name": "d"
+              }
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        687,
+        837
+      ],
+      "loc": {
+        "start": {
+          "line": 22,
+          "column": 0
+        },
+        "end": {
+          "line": 28,
+          "column": 1
+        }
+      },
+      "type": "FunctionDeclaration",
+      "id": {
+        "range": [
+          696,
+          699
+        ],
+        "loc": {
+          "start": {
+            "line": 22,
+            "column": 9
+          },
+          "end": {
+            "line": 22,
+            "column": 12
+          }
+        },
+        "type": "Identifier",
+        "name": "fn1"
+      },
+      "params": [
+        {
+          "range": [
+            700,
+            701
+          ],
+          "loc": {
+            "start": {
+              "line": 22,
+              "column": 13
+            },
+            "end": {
+              "line": 22,
+              "column": 14
+            }
+          },
+          "type": "Identifier",
+          "name": "n"
+        }
+      ],
+      "body": {
+        "range": [
+          703,
+          837
+        ],
+        "loc": {
+          "start": {
+            "line": 22,
+            "column": 16
+          },
+          "end": {
+            "line": 28,
+            "column": 1
+          }
+        },
+        "type": "BlockStatement",
+        "body": [
+          {
+            "range": [
+              707,
+              758
+            ],
+            "loc": {
+              "start": {
+                "line": 23,
+                "column": 2
+              },
+              "end": {
+                "line": 23,
+                "column": 53
+              }
+            },
+            "type": "IfStatement",
+            "test": {
+              "range": [
+                711,
+                712
+              ],
+              "loc": {
+                "start": {
+                  "line": 23,
+                  "column": 6
+                },
+                "end": {
+                  "line": 23,
+                  "column": 7
+                }
+              },
+              "type": "Identifier",
+              "name": "n"
+            },
+            "consequent": {
+              "range": [
+                714,
+                758
+              ],
+              "loc": {
+                "start": {
+                  "line": 23,
+                  "column": 9
+                },
+                "end": {
+                  "line": 23,
+                  "column": 53
+                }
+              },
+              "type": "ReturnStatement",
+              "argument": {
+                "range": [
+                  721,
+                  757
+                ],
+                "loc": {
+                  "start": {
+                    "line": 23,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 23,
+                    "column": 52
+                  }
+                },
+                "type": "ConditionalExpression",
+                "test": {
+                  "range": [
+                    721,
+                    740
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 23,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 23,
+                      "column": 35
+                    }
+                  },
+                  "type": "CallExpression",
+                  "callee": {
+                    "range": [
+                      721,
+                      729
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 23,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 23,
+                        "column": 24
+                      }
+                    },
+                    "type": "MemberExpression",
+                    "computed": false,
+                    "optional": false,
+                    "object": {
+                      "range": [
+                        721,
+                        724
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 23,
+                          "column": 16
+                        },
+                        "end": {
+                          "line": 23,
+                          "column": 19
+                        }
+                      },
+                      "type": "Literal",
+                      "value": {},
+                      "raw": "/a/",
+                      "regex": {
+                        "pattern": "a",
+                        "flags": ""
+                      }
+                    },
+                    "property": {
+                      "range": [
+                        725,
+                        729
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 23,
+                          "column": 20
+                        },
+                        "end": {
+                          "line": 23,
+                          "column": 24
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "test"
+                    }
+                  },
+                  "optional": false,
+                  "arguments": [
+                    {
+                      "range": [
+                        730,
+                        739
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 23,
+                          "column": 25
+                        },
+                        "end": {
+                          "line": 23,
+                          "column": 34
+                        }
+                      },
+                      "type": "CallExpression",
+                      "callee": {
+                        "range": [
+                          730,
+                          736
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 23,
+                            "column": 25
+                          },
+                          "end": {
+                            "line": 23,
+                            "column": 31
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "String"
+                      },
+                      "optional": false,
+                      "arguments": [
+                        {
+                          "range": [
+                            737,
+                            738
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 23,
+                              "column": 32
+                            },
+                            "end": {
+                              "line": 23,
+                              "column": 33
+                            }
+                          },
+                          "type": "Identifier",
+                          "name": "n"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "consequent": {
+                  "range": [
+                    743,
+                    748
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 23,
+                      "column": 38
+                    },
+                    "end": {
+                      "line": 23,
+                      "column": 43
+                    }
+                  },
+                  "type": "BinaryExpression",
+                  "operator": "/",
+                  "left": {
+                    "range": [
+                      743,
+                      746
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 23,
+                        "column": 38
+                      },
+                      "end": {
+                        "line": 23,
+                        "column": 41
+                      }
+                    },
+                    "type": "BinaryExpression",
+                    "operator": "/",
+                    "left": {
+                      "range": [
+                        743,
+                        744
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 23,
+                          "column": 38
+                        },
+                        "end": {
+                          "line": 23,
+                          "column": 39
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "n"
+                    },
+                    "right": {
+                      "range": [
+                        745,
+                        746
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 23,
+                          "column": 40
+                        },
+                        "end": {
+                          "line": 23,
+                          "column": 41
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "g"
+                    }
+                  },
+                  "right": {
+                    "range": [
+                      747,
+                      748
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 23,
+                        "column": 42
+                      },
+                      "end": {
+                        "line": 23,
+                        "column": 43
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "i"
+                  }
+                },
+                "alternate": {
+                  "range": [
+                    751,
+                    757
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 23,
+                      "column": 46
+                    },
+                    "end": {
+                      "line": 23,
+                      "column": 52
+                    }
+                  },
+                  "type": "BinaryExpression",
+                  "operator": "/",
+                  "left": {
+                    "range": [
+                      751,
+                      755
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 23,
+                        "column": 46
+                      },
+                      "end": {
+                        "line": 23,
+                        "column": 50
+                      }
+                    },
+                    "type": "BinaryExpression",
+                    "operator": "/",
+                    "left": {
+                      "range": [
+                        751,
+                        753
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 23,
+                          "column": 46
+                        },
+                        "end": {
+                          "line": 23,
+                          "column": 48
+                        }
+                      },
+                      "type": "UnaryExpression",
+                      "operator": "-",
+                      "argument": {
+                        "range": [
+                          752,
+                          753
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 23,
+                            "column": 47
+                          },
+                          "end": {
+                            "line": 23,
+                            "column": 48
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "n"
+                      },
+                      "prefix": true
+                    },
+                    "right": {
+                      "range": [
+                        754,
+                        755
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 23,
+                          "column": 49
+                        },
+                        "end": {
+                          "line": 23,
+                          "column": 50
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "y"
+                    }
+                  },
+                  "right": {
+                    "range": [
+                      756,
+                      757
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 23,
+                        "column": 51
+                      },
+                      "end": {
+                        "line": 23,
+                        "column": 52
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "d"
+                  }
+                }
+              }
+            },
+            "alternate": null
+          },
+          {
+            "range": [
+              761,
+              819
+            ],
+            "loc": {
+              "start": {
+                "line": 24,
+                "column": 2
+              },
+              "end": {
+                "line": 26,
+                "column": 3
+              }
+            },
+            "type": "SwitchStatement",
+            "discriminant": {
+              "range": [
+                769,
+                770
+              ],
+              "loc": {
+                "start": {
+                  "line": 24,
+                  "column": 10
+                },
+                "end": {
+                  "line": 24,
+                  "column": 11
+                }
+              },
+              "type": "Identifier",
+              "name": "n"
+            },
+            "cases": [
+              {
+                "range": [
+                  778,
+                  815
+                ],
+                "loc": {
+                  "start": {
+                    "line": 25,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 25,
+                    "column": 41
+                  }
+                },
+                "type": "SwitchCase",
+                "test": {
+                  "range": [
+                    783,
+                    784
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 25,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 25,
+                      "column": 10
+                    }
+                  },
+                  "type": "Literal",
+                  "value": 0,
+                  "raw": "0"
+                },
+                "consequent": [
+                  {
+                    "range": [
+                      786,
+                      815
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 25,
+                        "column": 12
+                      },
+                      "end": {
+                        "line": 25,
+                        "column": 41
+                      }
+                    },
+                    "type": "ReturnStatement",
+                    "argument": {
+                      "range": [
+                        793,
+                        814
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 25,
+                          "column": 19
+                        },
+                        "end": {
+                          "line": 25,
+                          "column": 40
+                        }
+                      },
+                      "type": "BinaryExpression",
+                      "operator": "/",
+                      "left": {
+                        "range": [
+                          793,
+                          812
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 25,
+                            "column": 19
+                          },
+                          "end": {
+                            "line": 25,
+                            "column": 38
+                          }
+                        },
+                        "type": "BinaryExpression",
+                        "operator": "/",
+                        "left": {
+                          "range": [
+                            793,
+                            810
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 25,
+                              "column": 19
+                            },
+                            "end": {
+                              "line": 25,
+                              "column": 36
+                            }
+                          },
+                          "type": "MemberExpression",
+                          "computed": false,
+                          "optional": false,
+                          "object": {
+                            "range": [
+                              793,
+                              803
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 25,
+                                "column": 19
+                              },
+                              "end": {
+                                "line": 25,
+                                "column": 29
+                              }
+                            },
+                            "type": "MemberExpression",
+                            "computed": false,
+                            "optional": false,
+                            "object": {
+                              "range": [
+                                793,
+                                796
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 25,
+                                  "column": 19
+                                },
+                                "end": {
+                                  "line": 25,
+                                  "column": 22
+                                }
+                              },
+                              "type": "Literal",
+                              "value": {},
+                              "raw": "/b/",
+                              "regex": {
+                                "pattern": "b",
+                                "flags": ""
+                              }
+                            },
+                            "property": {
+                              "range": [
+                                797,
+                                803
+                              ],
+                              "loc": {
+                                "start": {
+                                  "line": 25,
+                                  "column": 23
+                                },
+                                "end": {
+                                  "line": 25,
+                                  "column": 29
+                                }
+                              },
+                              "type": "Identifier",
+                              "name": "source"
+                            }
+                          },
+                          "property": {
+                            "range": [
+                              804,
+                              810
+                            ],
+                            "loc": {
+                              "start": {
+                                "line": 25,
+                                "column": 30
+                              },
+                              "end": {
+                                "line": 25,
+                                "column": 36
+                              }
+                            },
+                            "type": "Identifier",
+                            "name": "length"
+                          }
+                        },
+                        "right": {
+                          "range": [
+                            811,
+                            812
+                          ],
+                          "loc": {
+                            "start": {
+                              "line": 25,
+                              "column": 37
+                            },
+                            "end": {
+                              "line": 25,
+                              "column": 38
+                            }
+                          },
+                          "type": "Identifier",
+                          "name": "g"
+                        }
+                      },
+                      "right": {
+                        "range": [
+                          813,
+                          814
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 25,
+                            "column": 39
+                          },
+                          "end": {
+                            "line": 25,
+                            "column": 40
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "i"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "range": [
+              822,
+              835
+            ],
+            "loc": {
+              "start": {
+                "line": 27,
+                "column": 2
+              },
+              "end": {
+                "line": 27,
+                "column": 15
+              }
+            },
+            "type": "ReturnStatement",
+            "argument": {
+              "range": [
+                829,
+                834
+              ],
+              "loc": {
+                "start": {
+                  "line": 27,
+                  "column": 9
+                },
+                "end": {
+                  "line": 27,
+                  "column": 14
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  829,
+                  832
+                ],
+                "loc": {
+                  "start": {
+                    "line": 27,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 27,
+                    "column": 12
+                  }
+                },
+                "type": "BinaryExpression",
+                "operator": "/",
+                "left": {
+                  "range": [
+                    829,
+                    830
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 27,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 27,
+                      "column": 10
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "n"
+                },
+                "right": {
+                  "range": [
+                    831,
+                    832
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 27,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 27,
+                      "column": 12
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "y"
+                }
+              },
+              "right": {
+                "range": [
+                  833,
+                  834
+                ],
+                "loc": {
+                  "start": {
+                    "line": 27,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 27,
+                    "column": 14
+                  }
+                },
+                "type": "Identifier",
+                "name": "d"
+              }
+            }
+          }
+        ]
+      },
+      "generator": false,
+      "expression": false
+    },
+    {
+      "range": [
+        839,
+        877
+      ],
+      "loc": {
+        "start": {
+          "line": 30,
+          "column": 0
+        },
+        "end": {
+          "line": 30,
+          "column": 38
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            845,
+            876
+          ],
+          "loc": {
+            "start": {
+              "line": 30,
+              "column": 6
+            },
+            "end": {
+              "line": 30,
+              "column": 37
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              845,
+              848
+            ],
+            "loc": {
+              "start": {
+                "line": 30,
+                "column": 6
+              },
+              "end": {
+                "line": 30,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "res"
+          },
+          "init": {
+            "range": [
+              851,
+              876
+            ],
+            "loc": {
+              "start": {
+                "line": 30,
+                "column": 12
+              },
+              "end": {
+                "line": 30,
+                "column": 37
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "+",
+            "left": {
+              "range": [
+                851,
+                866
+              ],
+              "loc": {
+                "start": {
+                  "line": 30,
+                  "column": 12
+                },
+                "end": {
+                  "line": 30,
+                  "column": 27
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "+",
+              "left": {
+                "range": [
+                  851,
+                  857
+                ],
+                "loc": {
+                  "start": {
+                    "line": 30,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 30,
+                    "column": 18
+                  }
+                },
+                "type": "CallExpression",
+                "callee": {
+                  "range": [
+                    851,
+                    854
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 30,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 30,
+                      "column": 15
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "fn1"
+                },
+                "optional": false,
+                "arguments": [
+                  {
+                    "range": [
+                      855,
+                      856
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 30,
+                        "column": 16
+                      },
+                      "end": {
+                        "line": 30,
+                        "column": 17
+                      }
+                    },
+                    "type": "Literal",
+                    "value": 0,
+                    "raw": "0"
+                  }
+                ]
+              },
+              "right": {
+                "range": [
+                  860,
+                  866
+                ],
+                "loc": {
+                  "start": {
+                    "line": 30,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 30,
+                    "column": 27
+                  }
+                },
+                "type": "CallExpression",
+                "callee": {
+                  "range": [
+                    860,
+                    863
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 30,
+                      "column": 21
+                    },
+                    "end": {
+                      "line": 30,
+                      "column": 24
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "fn1"
+                },
+                "optional": false,
+                "arguments": [
+                  {
+                    "range": [
+                      864,
+                      865
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 30,
+                        "column": 25
+                      },
+                      "end": {
+                        "line": 30,
+                        "column": 26
+                      }
+                    },
+                    "type": "Literal",
+                    "value": 1,
+                    "raw": "1"
+                  }
+                ]
+              }
+            },
+            "right": {
+              "range": [
+                869,
+                876
+              ],
+              "loc": {
+                "start": {
+                  "line": 30,
+                  "column": 30
+                },
+                "end": {
+                  "line": 30,
+                  "column": 37
+                }
+              },
+              "type": "CallExpression",
+              "callee": {
+                "range": [
+                  869,
+                  872
+                ],
+                "loc": {
+                  "start": {
+                    "line": 30,
+                    "column": 30
+                  },
+                  "end": {
+                    "line": 30,
+                    "column": 33
+                  }
+                },
+                "type": "Identifier",
+                "name": "fn1"
+              },
+              "optional": false,
+              "arguments": [
+                {
+                  "range": [
+                    873,
+                    875
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 30,
+                      "column": 34
+                    },
+                    "end": {
+                      "line": 30,
+                      "column": 36
+                    }
+                  },
+                  "type": "UnaryExpression",
+                  "operator": "-",
+                  "argument": {
+                    "range": [
+                      874,
+                      875
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 30,
+                        "column": 35
+                      },
+                      "end": {
+                        "line": 30,
+                        "column": 36
+                      }
+                    },
+                    "type": "Literal",
+                    "value": 1,
+                    "raw": "1"
+                  },
+                  "prefix": true
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        878,
+        933
+      ],
+      "loc": {
+        "start": {
+          "line": 31,
+          "column": 0
+        },
+        "end": {
+          "line": 31,
+          "column": 55
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            884,
+            932
+          ],
+          "loc": {
+            "start": {
+              "line": 31,
+              "column": 6
+            },
+            "end": {
+              "line": 31,
+              "column": 54
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              884,
+              887
+            ],
+            "loc": {
+              "start": {
+                "line": 31,
+                "column": 6
+              },
+              "end": {
+                "line": 31,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "fn2"
+          },
+          "init": {
+            "range": [
+              890,
+              932
+            ],
+            "loc": {
+              "start": {
+                "line": 31,
+                "column": 12
+              },
+              "end": {
+                "line": 31,
+                "column": 54
+              }
+            },
+            "type": "ArrowFunctionExpression",
+            "params": [
+              {
+                "range": [
+                  891,
+                  892
+                ],
+                "loc": {
+                  "start": {
+                    "line": 31,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 31,
+                    "column": 14
+                  }
+                },
+                "type": "Identifier",
+                "name": "n"
+              }
+            ],
+            "body": {
+              "range": [
+                897,
+                932
+              ],
+              "loc": {
+                "start": {
+                  "line": 31,
+                  "column": 19
+                },
+                "end": {
+                  "line": 31,
+                  "column": 54
+                }
+              },
+              "type": "ConditionalExpression",
+              "test": {
+                "range": [
+                  897,
+                  902
+                ],
+                "loc": {
+                  "start": {
+                    "line": 31,
+                    "column": 19
+                  },
+                  "end": {
+                    "line": 31,
+                    "column": 24
+                  }
+                },
+                "type": "BinaryExpression",
+                "operator": ">",
+                "left": {
+                  "range": [
+                    897,
+                    898
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 31,
+                      "column": 19
+                    },
+                    "end": {
+                      "line": 31,
+                      "column": 20
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "n"
+                },
+                "right": {
+                  "range": [
+                    901,
+                    902
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 31,
+                      "column": 23
+                    },
+                    "end": {
+                      "line": 31,
+                      "column": 24
+                    }
+                  },
+                  "type": "Literal",
+                  "value": 0,
+                  "raw": "0"
+                }
+              },
+              "consequent": {
+                "range": [
+                  905,
+                  910
+                ],
+                "loc": {
+                  "start": {
+                    "line": 31,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 31,
+                    "column": 32
+                  }
+                },
+                "type": "BinaryExpression",
+                "operator": "/",
+                "left": {
+                  "range": [
+                    905,
+                    908
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 31,
+                      "column": 27
+                    },
+                    "end": {
+                      "line": 31,
+                      "column": 30
+                    }
+                  },
+                  "type": "BinaryExpression",
+                  "operator": "/",
+                  "left": {
+                    "range": [
+                      905,
+                      906
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 31,
+                        "column": 27
+                      },
+                      "end": {
+                        "line": 31,
+                        "column": 28
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "n"
+                  },
+                  "right": {
+                    "range": [
+                      907,
+                      908
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 31,
+                        "column": 29
+                      },
+                      "end": {
+                        "line": 31,
+                        "column": 30
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "g"
+                  }
+                },
+                "right": {
+                  "range": [
+                    909,
+                    910
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 31,
+                      "column": 31
+                    },
+                    "end": {
+                      "line": 31,
+                      "column": 32
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "i"
+                }
+              },
+              "alternate": {
+                "range": [
+                  913,
+                  932
+                ],
+                "loc": {
+                  "start": {
+                    "line": 31,
+                    "column": 35
+                  },
+                  "end": {
+                    "line": 31,
+                    "column": 54
+                  }
+                },
+                "type": "CallExpression",
+                "callee": {
+                  "range": [
+                    913,
+                    921
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 31,
+                      "column": 35
+                    },
+                    "end": {
+                      "line": 31,
+                      "column": 43
+                    }
+                  },
+                  "type": "MemberExpression",
+                  "computed": false,
+                  "optional": false,
+                  "object": {
+                    "range": [
+                      913,
+                      916
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 31,
+                        "column": 35
+                      },
+                      "end": {
+                        "line": 31,
+                        "column": 38
+                      }
+                    },
+                    "type": "Literal",
+                    "value": {},
+                    "raw": "/c/",
+                    "regex": {
+                      "pattern": "c",
+                      "flags": ""
+                    }
+                  },
+                  "property": {
+                    "range": [
+                      917,
+                      921
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 31,
+                        "column": 39
+                      },
+                      "end": {
+                        "line": 31,
+                        "column": 43
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "test"
+                  }
+                },
+                "optional": false,
+                "arguments": [
+                  {
+                    "range": [
+                      922,
+                      931
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 31,
+                        "column": 44
+                      },
+                      "end": {
+                        "line": 31,
+                        "column": 53
+                      }
+                    },
+                    "type": "CallExpression",
+                    "callee": {
+                      "range": [
+                        922,
+                        928
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 31,
+                          "column": 44
+                        },
+                        "end": {
+                          "line": 31,
+                          "column": 50
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "String"
+                    },
+                    "optional": false,
+                    "arguments": [
+                      {
+                        "range": [
+                          929,
+                          930
+                        ],
+                        "loc": {
+                          "start": {
+                            "line": 31,
+                            "column": 51
+                          },
+                          "end": {
+                            "line": 31,
+                            "column": 52
+                          }
+                        },
+                        "type": "Identifier",
+                        "name": "n"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "expression": true
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        976,
+        1031
+      ],
+      "loc": {
+        "start": {
+          "line": 34,
+          "column": 0
+        },
+        "end": {
+          "line": 34,
+          "column": 55
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            982,
+            1006
+          ],
+          "loc": {
+            "start": {
+              "line": 34,
+              "column": 6
+            },
+            "end": {
+              "line": 34,
+              "column": 30
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              982,
+              984
+            ],
+            "loc": {
+              "start": {
+                "line": 34,
+                "column": 6
+              },
+              "end": {
+                "line": 34,
+                "column": 8
+              }
+            },
+            "type": "Identifier",
+            "name": "t1"
+          },
+          "init": {
+            "range": [
+              987,
+              1006
+            ],
+            "loc": {
+              "start": {
+                "line": 34,
+                "column": 11
+              },
+              "end": {
+                "line": 34,
+                "column": 30
+              }
+            },
+            "type": "TemplateLiteral",
+            "quasis": [
+              {
+                "range": [
+                  987,
+                  992
+                ],
+                "loc": {
+                  "start": {
+                    "line": 34,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 34,
+                    "column": 16
+                  }
+                },
+                "type": "TemplateElement",
+                "tail": false,
+                "value": {
+                  "cooked": "n=",
+                  "raw": "n="
+                }
+              },
+              {
+                "range": [
+                  1004,
+                  1006
+                ],
+                "loc": {
+                  "start": {
+                    "line": 34,
+                    "column": 28
+                  },
+                  "end": {
+                    "line": 34,
+                    "column": 30
+                  }
+                },
+                "type": "TemplateElement",
+                "tail": true,
+                "value": {
+                  "cooked": "",
+                  "raw": ""
+                }
+              }
+            ],
+            "expressions": [
+              {
+                "range": [
+                  992,
+                  1004
+                ],
+                "loc": {
+                  "start": {
+                    "line": 34,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 34,
+                    "column": 28
+                  }
+                },
+                "type": "MemberExpression",
+                "computed": false,
+                "optional": false,
+                "object": {
+                  "range": [
+                    992,
+                    997
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 34,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 34,
+                      "column": 21
+                    }
+                  },
+                  "type": "Literal",
+                  "value": {},
+                  "raw": "/\\d+/",
+                  "regex": {
+                    "pattern": "\\d+",
+                    "flags": ""
+                  }
+                },
+                "property": {
+                  "range": [
+                    998,
+                    1004
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 34,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 34,
+                      "column": 28
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "source"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "range": [
+            1008,
+            1030
+          ],
+          "loc": {
+            "start": {
+              "line": 34,
+              "column": 32
+            },
+            "end": {
+              "line": 34,
+              "column": 54
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              1008,
+              1010
+            ],
+            "loc": {
+              "start": {
+                "line": 34,
+                "column": 32
+              },
+              "end": {
+                "line": 34,
+                "column": 34
+              }
+            },
+            "type": "Identifier",
+            "name": "t2"
+          },
+          "init": {
+            "range": [
+              1013,
+              1030
+            ],
+            "loc": {
+              "start": {
+                "line": 34,
+                "column": 37
+              },
+              "end": {
+                "line": 34,
+                "column": 54
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "/",
+            "left": {
+              "range": [
+                1013,
+                1028
+              ],
+              "loc": {
+                "start": {
+                  "line": 34,
+                  "column": 37
+                },
+                "end": {
+                  "line": 34,
+                  "column": 52
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "/",
+              "left": {
+                "range": [
+                  1013,
+                  1026
+                ],
+                "loc": {
+                  "start": {
+                    "line": 34,
+                    "column": 37
+                  },
+                  "end": {
+                    "line": 34,
+                    "column": 50
+                  }
+                },
+                "type": "MemberExpression",
+                "computed": false,
+                "optional": false,
+                "object": {
+                  "range": [
+                    1013,
+                    1019
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 34,
+                      "column": 37
+                    },
+                    "end": {
+                      "line": 34,
+                      "column": 43
+                    }
+                  },
+                  "type": "TemplateLiteral",
+                  "quasis": [
+                    {
+                      "range": [
+                        1013,
+                        1016
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 34,
+                          "column": 37
+                        },
+                        "end": {
+                          "line": 34,
+                          "column": 40
+                        }
+                      },
+                      "type": "TemplateElement",
+                      "tail": false,
+                      "value": {
+                        "cooked": "",
+                        "raw": ""
+                      }
+                    },
+                    {
+                      "range": [
+                        1017,
+                        1019
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 34,
+                          "column": 41
+                        },
+                        "end": {
+                          "line": 34,
+                          "column": 43
+                        }
+                      },
+                      "type": "TemplateElement",
+                      "tail": true,
+                      "value": {
+                        "cooked": "",
+                        "raw": ""
+                      }
+                    }
+                  ],
+                  "expressions": [
+                    {
+                      "range": [
+                        1016,
+                        1017
+                      ],
+                      "loc": {
+                        "start": {
+                          "line": 34,
+                          "column": 40
+                        },
+                        "end": {
+                          "line": 34,
+                          "column": 41
+                        }
+                      },
+                      "type": "Identifier",
+                      "name": "q"
+                    }
+                  ]
+                },
+                "property": {
+                  "range": [
+                    1020,
+                    1026
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 34,
+                      "column": 44
+                    },
+                    "end": {
+                      "line": 34,
+                      "column": 50
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "length"
+                }
+              },
+              "right": {
+                "range": [
+                  1027,
+                  1028
+                ],
+                "loc": {
+                  "start": {
+                    "line": 34,
+                    "column": 51
+                  },
+                  "end": {
+                    "line": 34,
+                    "column": 52
+                  }
+                },
+                "type": "Identifier",
+                "name": "g"
+              }
+            },
+            "right": {
+              "range": [
+                1029,
+                1030
+              ],
+              "loc": {
+                "start": {
+                  "line": 34,
+                  "column": 53
+                },
+                "end": {
+                  "line": 34,
+                  "column": 54
+                }
+              },
+              "type": "Identifier",
+              "name": "i"
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        1032,
+        1110
+      ],
+      "loc": {
+        "start": {
+          "line": 35,
+          "column": 0
+        },
+        "end": {
+          "line": 35,
+          "column": 78
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            1038,
+            1059
+          ],
+          "loc": {
+            "start": {
+              "line": 35,
+              "column": 6
+            },
+            "end": {
+              "line": 35,
+              "column": 27
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              1038,
+              1040
+            ],
+            "loc": {
+              "start": {
+                "line": 35,
+                "column": 6
+              },
+              "end": {
+                "line": 35,
+                "column": 8
+              }
+            },
+            "type": "Identifier",
+            "name": "t3"
+          },
+          "init": {
+            "range": [
+              1043,
+              1059
+            ],
+            "loc": {
+              "start": {
+                "line": 35,
+                "column": 11
+              },
+              "end": {
+                "line": 35,
+                "column": 27
+              }
+            },
+            "type": "UnaryExpression",
+            "operator": "void",
+            "argument": {
+              "range": [
+                1048,
+                1059
+              ],
+              "loc": {
+                "start": {
+                  "line": 35,
+                  "column": 16
+                },
+                "end": {
+                  "line": 35,
+                  "column": 27
+                }
+              },
+              "type": "MemberExpression",
+              "computed": false,
+              "optional": false,
+              "object": {
+                "range": [
+                  1048,
+                  1052
+                ],
+                "loc": {
+                  "start": {
+                    "line": 35,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 35,
+                    "column": 20
+                  }
+                },
+                "type": "Literal",
+                "value": {},
+                "raw": "/gi/",
+                "regex": {
+                  "pattern": "gi",
+                  "flags": ""
+                }
+              },
+              "property": {
+                "range": [
+                  1053,
+                  1059
+                ],
+                "loc": {
+                  "start": {
+                    "line": 35,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 35,
+                    "column": 27
+                  }
+                },
+                "type": "Identifier",
+                "name": "source"
+              }
+            },
+            "prefix": true
+          }
+        },
+        {
+          "range": [
+            1061,
+            1109
+          ],
+          "loc": {
+            "start": {
+              "line": 35,
+              "column": 29
+            },
+            "end": {
+              "line": 35,
+              "column": 77
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              1061,
+              1063
+            ],
+            "loc": {
+              "start": {
+                "line": 35,
+                "column": 29
+              },
+              "end": {
+                "line": 35,
+                "column": 31
+              }
+            },
+            "type": "Identifier",
+            "name": "t4"
+          },
+          "init": {
+            "range": [
+              1066,
+              1109
+            ],
+            "loc": {
+              "start": {
+                "line": 35,
+                "column": 34
+              },
+              "end": {
+                "line": 35,
+                "column": 77
+              }
+            },
+            "type": "ConditionalExpression",
+            "test": {
+              "range": [
+                1066,
+                1085
+              ],
+              "loc": {
+                "start": {
+                  "line": 35,
+                  "column": 34
+                },
+                "end": {
+                  "line": 35,
+                  "column": 53
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "instanceof",
+              "left": {
+                "range": [
+                  1066,
+                  1067
+                ],
+                "loc": {
+                  "start": {
+                    "line": 35,
+                    "column": 34
+                  },
+                  "end": {
+                    "line": 35,
+                    "column": 35
+                  }
+                },
+                "type": "Identifier",
+                "name": "p"
+              },
+              "right": {
+                "range": [
+                  1079,
+                  1085
+                ],
+                "loc": {
+                  "start": {
+                    "line": 35,
+                    "column": 47
+                  },
+                  "end": {
+                    "line": 35,
+                    "column": 53
+                  }
+                },
+                "type": "Identifier",
+                "name": "RegExp"
+              }
+            },
+            "consequent": {
+              "range": [
+                1088,
+                1095
+              ],
+              "loc": {
+                "start": {
+                  "line": 35,
+                  "column": 56
+                },
+                "end": {
+                  "line": 35,
+                  "column": 63
+                }
+              },
+              "type": "MemberExpression",
+              "computed": false,
+              "optional": false,
+              "object": {
+                "range": [
+                  1088,
+                  1089
+                ],
+                "loc": {
+                  "start": {
+                    "line": 35,
+                    "column": 56
+                  },
+                  "end": {
+                    "line": 35,
+                    "column": 57
+                  }
+                },
+                "type": "Identifier",
+                "name": "p"
+              },
+              "property": {
+                "range": [
+                  1090,
+                  1095
+                ],
+                "loc": {
+                  "start": {
+                    "line": 35,
+                    "column": 58
+                  },
+                  "end": {
+                    "line": 35,
+                    "column": 63
+                  }
+                },
+                "type": "Identifier",
+                "name": "flags"
+              }
+            },
+            "alternate": {
+              "range": [
+                1098,
+                1109
+              ],
+              "loc": {
+                "start": {
+                  "line": 35,
+                  "column": 66
+                },
+                "end": {
+                  "line": 35,
+                  "column": 77
+                }
+              },
+              "type": "MemberExpression",
+              "computed": false,
+              "optional": false,
+              "object": {
+                "range": [
+                  1098,
+                  1102
+                ],
+                "loc": {
+                  "start": {
+                    "line": 35,
+                    "column": 66
+                  },
+                  "end": {
+                    "line": 35,
+                    "column": 70
+                  }
+                },
+                "type": "Literal",
+                "value": {},
+                "raw": "/m/g",
+                "regex": {
+                  "pattern": "m",
+                  "flags": "g"
+                }
+              },
+              "property": {
+                "range": [
+                  1103,
+                  1109
+                ],
+                "loc": {
+                  "start": {
+                    "line": 35,
+                    "column": 71
+                  },
+                  "end": {
+                    "line": 35,
+                    "column": 77
+                  }
+                },
+                "type": "Identifier",
+                "name": "source"
+              }
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        1112,
+        1146
+      ],
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 0
+        },
+        "end": {
+          "line": 37,
+          "column": 34
+        }
+      },
+      "type": "BlockStatement",
+      "body": []
+    },
+    {
+      "range": [
+        1147,
+        1174
+      ],
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 0
+        },
+        "end": {
+          "line": 38,
+          "column": 27
+        }
+      },
+      "type": "ExpressionStatement",
+      "expression": {
+        "range": [
+          1147,
+          1173
+        ],
+        "loc": {
+          "start": {
+            "line": 38,
+            "column": 0
+          },
+          "end": {
+            "line": 38,
+            "column": 26
+          }
+        },
+        "type": "CallExpression",
+        "callee": {
+          "range": [
+            1147,
+            1159
+          ],
+          "loc": {
+            "start": {
+              "line": 38,
+              "column": 0
+            },
+            "end": {
+              "line": 38,
+              "column": 12
+            }
+          },
+          "type": "MemberExpression",
+          "computed": false,
+          "optional": false,
+          "object": {
+            "range": [
+              1147,
+              1154
+            ],
+            "loc": {
+              "start": {
+                "line": 38,
+                "column": 0
+              },
+              "end": {
+                "line": 38,
+                "column": 7
+              }
+            },
+            "type": "Literal",
+            "value": {},
+            "raw": "/start/",
+            "regex": {
+              "pattern": "start",
+              "flags": ""
+            }
+          },
+          "property": {
+            "range": [
+              1155,
+              1159
+            ],
+            "loc": {
+              "start": {
+                "line": 38,
+                "column": 8
+              },
+              "end": {
+                "line": 38,
+                "column": 12
+              }
+            },
+            "type": "Identifier",
+            "name": "test"
+          }
+        },
+        "optional": false,
+        "arguments": [
+          {
+            "range": [
+              1160,
+              1172
+            ],
+            "loc": {
+              "start": {
+                "line": 38,
+                "column": 13
+              },
+              "end": {
+                "line": 38,
+                "column": 25
+              }
+            },
+            "type": "Literal",
+            "value": "line start",
+            "raw": "'line start'"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/test-0385-tokenize-expected.json
+++ b/tests/fixtures/test-0385-tokenize-expected.json
@@ -1,0 +1,1654 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "d"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "8"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "4"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "2"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "m"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "16"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "s"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "3"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "u"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "6"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "v"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "9"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "y"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "5"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "let"
+  },
+  {
+    "type": "Identifier",
+    "value": "p"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "10"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "q"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "12"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "a"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "d"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "b"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "m"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "s"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "u"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "c"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "v"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "y"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "d"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "e"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "d"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "f"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "["
+  },
+  {
+    "type": "Identifier",
+    "value": "m"
+  },
+  {
+    "type": "Punctuator",
+    "value": "]"
+  },
+  {
+    "type": "Punctuator",
+    "value": "["
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": "]"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "s"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "u"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "h"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "valueOf"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "j"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "--"
+  },
+  {
+    "type": "Identifier",
+    "value": "p"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "s"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "u"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "k"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "++"
+  },
+  {
+    "type": "Identifier",
+    "value": "q"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "y"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "d"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "l"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "p"
+  },
+  {
+    "type": "Punctuator",
+    "value": "++"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "x"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "q"
+  },
+  {
+    "type": "Punctuator",
+    "value": "--"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "s"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "u"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "let"
+  },
+  {
+    "type": "Identifier",
+    "value": "n1"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "1"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "n2"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "9"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "o1"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "n1"
+  },
+  {
+    "type": "Punctuator",
+    "value": "++"
+  },
+  {
+    "type": "Punctuator",
+    "value": "+"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/g/",
+    "regex": {
+      "pattern": "g",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "source"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "o2"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "n2"
+  },
+  {
+    "type": "Punctuator",
+    "value": "--"
+  },
+  {
+    "type": "Punctuator",
+    "value": "-"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/s/",
+    "regex": {
+      "pattern": "s",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "source"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "re1"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/=/g",
+    "regex": {
+      "pattern": "=",
+      "flags": "g"
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "re2"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/a\\/b\\/c/gimsu",
+    "regex": {
+      "pattern": "a\\/b\\/c",
+      "flags": "gimsu"
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "re3"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": ">"
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": "?"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/^\\d+$/",
+    "regex": {
+      "pattern": "^\\d+$",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/x/y",
+    "regex": {
+      "pattern": "x",
+      "flags": "y"
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "re4"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "["
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/g/",
+    "regex": {
+      "pattern": "g",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/i/m",
+    "regex": {
+      "pattern": "i",
+      "flags": "m"
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/s/u",
+    "regex": {
+      "pattern": "s",
+      "flags": "u"
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "re5"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "p"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/v/",
+    "regex": {
+      "pattern": "v",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "q"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "Identifier",
+    "value": "d"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "w"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Keyword",
+    "value": "typeof"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/re/",
+    "regex": {
+      "pattern": "re",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "==="
+  },
+  {
+    "type": "String",
+    "value": "'object'"
+  },
+  {
+    "type": "Punctuator",
+    "value": "?"
+  },
+  {
+    "type": "Identifier",
+    "value": "d"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "d"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "function"
+  },
+  {
+    "type": "Identifier",
+    "value": "fn1"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "if"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Keyword",
+    "value": "return"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/a/",
+    "regex": {
+      "pattern": "a",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "test"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "String"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "?"
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "Punctuator",
+    "value": "-"
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "y"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "d"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "switch"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Keyword",
+    "value": "case"
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "Keyword",
+    "value": "return"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/b/",
+    "regex": {
+      "pattern": "b",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "source"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "length"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "return"
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "y"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "d"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "res"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "fn1"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "+"
+  },
+  {
+    "type": "Identifier",
+    "value": "fn1"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Numeric",
+    "value": "1"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "+"
+  },
+  {
+    "type": "Identifier",
+    "value": "fn1"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": "-"
+  },
+  {
+    "type": "Numeric",
+    "value": "1"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "fn2"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "=>"
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": ">"
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": "?"
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/c/",
+    "regex": {
+      "pattern": "c",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "test"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "String"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "t1"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Template",
+    "value": "`n=${"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/\\d+/",
+    "regex": {
+      "pattern": "\\d+",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "source"
+  },
+  {
+    "type": "Template",
+    "value": "}`"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "t2"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Template",
+    "value": "`${"
+  },
+  {
+    "type": "Identifier",
+    "value": "q"
+  },
+  {
+    "type": "Template",
+    "value": "}`"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "length"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "g"
+  },
+  {
+    "type": "Punctuator",
+    "value": "/"
+  },
+  {
+    "type": "Identifier",
+    "value": "i"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "t3"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Keyword",
+    "value": "void"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/gi/",
+    "regex": {
+      "pattern": "gi",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "source"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "t4"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "p"
+  },
+  {
+    "type": "Keyword",
+    "value": "instanceof"
+  },
+  {
+    "type": "Identifier",
+    "value": "RegExp"
+  },
+  {
+    "type": "Punctuator",
+    "value": "?"
+  },
+  {
+    "type": "Identifier",
+    "value": "p"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "flags"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/m/g",
+    "regex": {
+      "pattern": "m",
+      "flags": "g"
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "source"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/start/",
+    "regex": {
+      "pattern": "start",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "test"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "String",
+    "value": "'line start'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  }
+]

--- a/tests/fixtures/test-0385-tokenize-loc-range-expected.json
+++ b/tests/fixtures/test-0385-tokenize-loc-range-expected.json
@@ -1,0 +1,7184 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      0,
+      5
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "d",
+    "range": [
+      6,
+      7
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      8,
+      9
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 8
+      },
+      "end": {
+        "line": 1,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "8",
+    "range": [
+      10,
+      11
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 10
+      },
+      "end": {
+        "line": 1,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      11,
+      12
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      13,
+      14
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 13
+      },
+      "end": {
+        "line": 1,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      15,
+      16
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 15
+      },
+      "end": {
+        "line": 1,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "4",
+    "range": [
+      17,
+      18
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 17
+      },
+      "end": {
+        "line": 1,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      18,
+      19
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 18
+      },
+      "end": {
+        "line": 1,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      20,
+      21
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 20
+      },
+      "end": {
+        "line": 1,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      22,
+      23
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 22
+      },
+      "end": {
+        "line": 1,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "2",
+    "range": [
+      24,
+      25
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 24
+      },
+      "end": {
+        "line": 1,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      25,
+      26
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 25
+      },
+      "end": {
+        "line": 1,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "m",
+    "range": [
+      27,
+      28
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 27
+      },
+      "end": {
+        "line": 1,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      29,
+      30
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 29
+      },
+      "end": {
+        "line": 1,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "16",
+    "range": [
+      31,
+      33
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 31
+      },
+      "end": {
+        "line": 1,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      33,
+      34
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 33
+      },
+      "end": {
+        "line": 1,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "s",
+    "range": [
+      35,
+      36
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 35
+      },
+      "end": {
+        "line": 1,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      37,
+      38
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 37
+      },
+      "end": {
+        "line": 1,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "3",
+    "range": [
+      39,
+      40
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 39
+      },
+      "end": {
+        "line": 1,
+        "column": 40
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      40,
+      41
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 40
+      },
+      "end": {
+        "line": 1,
+        "column": 41
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "u",
+    "range": [
+      42,
+      43
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 42
+      },
+      "end": {
+        "line": 1,
+        "column": 43
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      44,
+      45
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 44
+      },
+      "end": {
+        "line": 1,
+        "column": 45
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "6",
+    "range": [
+      46,
+      47
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 46
+      },
+      "end": {
+        "line": 1,
+        "column": 47
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      47,
+      48
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 47
+      },
+      "end": {
+        "line": 1,
+        "column": 48
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "v",
+    "range": [
+      49,
+      50
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 49
+      },
+      "end": {
+        "line": 1,
+        "column": 50
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      51,
+      52
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 51
+      },
+      "end": {
+        "line": 1,
+        "column": 52
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "9",
+    "range": [
+      53,
+      54
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 53
+      },
+      "end": {
+        "line": 1,
+        "column": 54
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      54,
+      55
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 54
+      },
+      "end": {
+        "line": 1,
+        "column": 55
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "y",
+    "range": [
+      56,
+      57
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 56
+      },
+      "end": {
+        "line": 1,
+        "column": 57
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      58,
+      59
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 58
+      },
+      "end": {
+        "line": 1,
+        "column": 59
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "5",
+    "range": [
+      60,
+      61
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 60
+      },
+      "end": {
+        "line": 1,
+        "column": 61
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      61,
+      62
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 61
+      },
+      "end": {
+        "line": 1,
+        "column": 62
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "let",
+    "range": [
+      63,
+      66
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "p",
+    "range": [
+      67,
+      68
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 4
+      },
+      "end": {
+        "line": 2,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      69,
+      70
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 6
+      },
+      "end": {
+        "line": 2,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "10",
+    "range": [
+      71,
+      73
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 8
+      },
+      "end": {
+        "line": 2,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      73,
+      74
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 10
+      },
+      "end": {
+        "line": 2,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "q",
+    "range": [
+      75,
+      76
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 12
+      },
+      "end": {
+        "line": 2,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      77,
+      78
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 14
+      },
+      "end": {
+        "line": 2,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "12",
+    "range": [
+      79,
+      81
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 16
+      },
+      "end": {
+        "line": 2,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      81,
+      82
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 18
+      },
+      "end": {
+        "line": 2,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      84,
+      89
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "a",
+    "range": [
+      90,
+      91
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 6
+      },
+      "end": {
+        "line": 4,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      92,
+      93
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 8
+      },
+      "end": {
+        "line": 4,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "d",
+    "range": [
+      94,
+      95
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 10
+      },
+      "end": {
+        "line": 4,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      95,
+      96
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 11
+      },
+      "end": {
+        "line": 4,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      96,
+      97
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 12
+      },
+      "end": {
+        "line": 4,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      97,
+      98
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 13
+      },
+      "end": {
+        "line": 4,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      98,
+      99
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 14
+      },
+      "end": {
+        "line": 4,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      99,
+      100
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 15
+      },
+      "end": {
+        "line": 4,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "b",
+    "range": [
+      101,
+      102
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 17
+      },
+      "end": {
+        "line": 4,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      103,
+      104
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 19
+      },
+      "end": {
+        "line": 4,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "m",
+    "range": [
+      105,
+      106
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 21
+      },
+      "end": {
+        "line": 4,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      106,
+      107
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 22
+      },
+      "end": {
+        "line": 4,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "s",
+    "range": [
+      107,
+      108
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 23
+      },
+      "end": {
+        "line": 4,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      108,
+      109
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 24
+      },
+      "end": {
+        "line": 4,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "u",
+    "range": [
+      109,
+      110
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 25
+      },
+      "end": {
+        "line": 4,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      110,
+      111
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 26
+      },
+      "end": {
+        "line": 4,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "c",
+    "range": [
+      112,
+      113
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 28
+      },
+      "end": {
+        "line": 4,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      114,
+      115
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 30
+      },
+      "end": {
+        "line": 4,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "v",
+    "range": [
+      116,
+      117
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 32
+      },
+      "end": {
+        "line": 4,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      117,
+      118
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 33
+      },
+      "end": {
+        "line": 4,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "y",
+    "range": [
+      118,
+      119
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 34
+      },
+      "end": {
+        "line": 4,
+        "column": 35
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      119,
+      120
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 35
+      },
+      "end": {
+        "line": 4,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "d",
+    "range": [
+      120,
+      121
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 36
+      },
+      "end": {
+        "line": 4,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      121,
+      122
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 37
+      },
+      "end": {
+        "line": 4,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      122,
+      123
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 38
+      },
+      "end": {
+        "line": 4,
+        "column": 39
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      123,
+      124
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 39
+      },
+      "end": {
+        "line": 4,
+        "column": 40
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      125,
+      130
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "e",
+    "range": [
+      131,
+      132
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 6
+      },
+      "end": {
+        "line": 5,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      133,
+      134
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 8
+      },
+      "end": {
+        "line": 5,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      135,
+      136
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 10
+      },
+      "end": {
+        "line": 5,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "d",
+    "range": [
+      136,
+      137
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 11
+      },
+      "end": {
+        "line": 5,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      137,
+      138
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 12
+      },
+      "end": {
+        "line": 5,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      138,
+      139
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 13
+      },
+      "end": {
+        "line": 5,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      139,
+      140
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 14
+      },
+      "end": {
+        "line": 5,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      140,
+      141
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 15
+      },
+      "end": {
+        "line": 5,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      141,
+      142
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 16
+      },
+      "end": {
+        "line": 5,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      142,
+      143
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 17
+      },
+      "end": {
+        "line": 5,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "f",
+    "range": [
+      144,
+      145
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 19
+      },
+      "end": {
+        "line": 5,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      146,
+      147
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 21
+      },
+      "end": {
+        "line": 5,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "[",
+    "range": [
+      148,
+      149
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 23
+      },
+      "end": {
+        "line": 5,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "m",
+    "range": [
+      149,
+      150
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 24
+      },
+      "end": {
+        "line": 5,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]",
+    "range": [
+      150,
+      151
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 25
+      },
+      "end": {
+        "line": 5,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "[",
+    "range": [
+      151,
+      152
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 26
+      },
+      "end": {
+        "line": 5,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      152,
+      153
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 27
+      },
+      "end": {
+        "line": 5,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]",
+    "range": [
+      153,
+      154
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 28
+      },
+      "end": {
+        "line": 5,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      154,
+      155
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 29
+      },
+      "end": {
+        "line": 5,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "s",
+    "range": [
+      155,
+      156
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 30
+      },
+      "end": {
+        "line": 5,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      156,
+      157
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 31
+      },
+      "end": {
+        "line": 5,
+        "column": 32
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "u",
+    "range": [
+      157,
+      158
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 32
+      },
+      "end": {
+        "line": 5,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      158,
+      159
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 33
+      },
+      "end": {
+        "line": 5,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "h",
+    "range": [
+      160,
+      161
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 35
+      },
+      "end": {
+        "line": 5,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      162,
+      163
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 37
+      },
+      "end": {
+        "line": 5,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      164,
+      165
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 39
+      },
+      "end": {
+        "line": 5,
+        "column": 40
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      165,
+      166
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 40
+      },
+      "end": {
+        "line": 5,
+        "column": 41
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "valueOf",
+    "range": [
+      166,
+      173
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 41
+      },
+      "end": {
+        "line": 5,
+        "column": 48
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      173,
+      174
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 48
+      },
+      "end": {
+        "line": 5,
+        "column": 49
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      174,
+      175
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 49
+      },
+      "end": {
+        "line": 5,
+        "column": 50
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      175,
+      176
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 50
+      },
+      "end": {
+        "line": 5,
+        "column": 51
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      176,
+      177
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 51
+      },
+      "end": {
+        "line": 5,
+        "column": 52
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      177,
+      178
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 52
+      },
+      "end": {
+        "line": 5,
+        "column": 53
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      178,
+      179
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 53
+      },
+      "end": {
+        "line": 5,
+        "column": 54
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      179,
+      180
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 54
+      },
+      "end": {
+        "line": 5,
+        "column": 55
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      244,
+      249
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 0
+      },
+      "end": {
+        "line": 8,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "j",
+    "range": [
+      250,
+      251
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 6
+      },
+      "end": {
+        "line": 8,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      252,
+      253
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 8
+      },
+      "end": {
+        "line": 8,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "--",
+    "range": [
+      254,
+      256
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 10
+      },
+      "end": {
+        "line": 8,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "p",
+    "range": [
+      256,
+      257
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 12
+      },
+      "end": {
+        "line": 8,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      257,
+      258
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 13
+      },
+      "end": {
+        "line": 8,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "s",
+    "range": [
+      258,
+      259
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 14
+      },
+      "end": {
+        "line": 8,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      259,
+      260
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 15
+      },
+      "end": {
+        "line": 8,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "u",
+    "range": [
+      260,
+      261
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 16
+      },
+      "end": {
+        "line": 8,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      261,
+      262
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 17
+      },
+      "end": {
+        "line": 8,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "k",
+    "range": [
+      263,
+      264
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 19
+      },
+      "end": {
+        "line": 8,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      265,
+      266
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 21
+      },
+      "end": {
+        "line": 8,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "++",
+    "range": [
+      267,
+      269
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 23
+      },
+      "end": {
+        "line": 8,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "q",
+    "range": [
+      269,
+      270
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 25
+      },
+      "end": {
+        "line": 8,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      270,
+      271
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 26
+      },
+      "end": {
+        "line": 8,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "y",
+    "range": [
+      271,
+      272
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 27
+      },
+      "end": {
+        "line": 8,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      272,
+      273
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 28
+      },
+      "end": {
+        "line": 8,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "d",
+    "range": [
+      273,
+      274
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 29
+      },
+      "end": {
+        "line": 8,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      274,
+      275
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 30
+      },
+      "end": {
+        "line": 8,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "l",
+    "range": [
+      276,
+      277
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 32
+      },
+      "end": {
+        "line": 8,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      278,
+      279
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 34
+      },
+      "end": {
+        "line": 8,
+        "column": 35
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "p",
+    "range": [
+      280,
+      281
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 36
+      },
+      "end": {
+        "line": 8,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "++",
+    "range": [
+      281,
+      283
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 37
+      },
+      "end": {
+        "line": 8,
+        "column": 39
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      283,
+      284
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 39
+      },
+      "end": {
+        "line": 8,
+        "column": 40
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      284,
+      285
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 40
+      },
+      "end": {
+        "line": 8,
+        "column": 41
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      285,
+      286
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 41
+      },
+      "end": {
+        "line": 8,
+        "column": 42
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      286,
+      287
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 42
+      },
+      "end": {
+        "line": 8,
+        "column": 43
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      287,
+      288
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 43
+      },
+      "end": {
+        "line": 8,
+        "column": 44
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "x",
+    "range": [
+      289,
+      290
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 45
+      },
+      "end": {
+        "line": 8,
+        "column": 46
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      291,
+      292
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 47
+      },
+      "end": {
+        "line": 8,
+        "column": 48
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "q",
+    "range": [
+      293,
+      294
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 49
+      },
+      "end": {
+        "line": 8,
+        "column": 50
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "--",
+    "range": [
+      294,
+      296
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 50
+      },
+      "end": {
+        "line": 8,
+        "column": 52
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      296,
+      297
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 52
+      },
+      "end": {
+        "line": 8,
+        "column": 53
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "s",
+    "range": [
+      297,
+      298
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 53
+      },
+      "end": {
+        "line": 8,
+        "column": 54
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      298,
+      299
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 54
+      },
+      "end": {
+        "line": 8,
+        "column": 55
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "u",
+    "range": [
+      299,
+      300
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 55
+      },
+      "end": {
+        "line": 8,
+        "column": 56
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      300,
+      301
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 56
+      },
+      "end": {
+        "line": 8,
+        "column": 57
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "let",
+    "range": [
+      303,
+      306
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 0
+      },
+      "end": {
+        "line": 10,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n1",
+    "range": [
+      307,
+      309
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 4
+      },
+      "end": {
+        "line": 10,
+        "column": 6
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      310,
+      311
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 7
+      },
+      "end": {
+        "line": 10,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "1",
+    "range": [
+      312,
+      313
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 9
+      },
+      "end": {
+        "line": 10,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      313,
+      314
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 10
+      },
+      "end": {
+        "line": 10,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n2",
+    "range": [
+      315,
+      317
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 12
+      },
+      "end": {
+        "line": 10,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      318,
+      319
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 15
+      },
+      "end": {
+        "line": 10,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "9",
+    "range": [
+      320,
+      321
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 17
+      },
+      "end": {
+        "line": 10,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      321,
+      322
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 18
+      },
+      "end": {
+        "line": 10,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      440,
+      445
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 0
+      },
+      "end": {
+        "line": 13,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "o1",
+    "range": [
+      446,
+      448
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 6
+      },
+      "end": {
+        "line": 13,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      449,
+      450
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 9
+      },
+      "end": {
+        "line": 13,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n1",
+    "range": [
+      451,
+      453
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 11
+      },
+      "end": {
+        "line": 13,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "++",
+    "range": [
+      453,
+      455
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 13
+      },
+      "end": {
+        "line": 13,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "+",
+    "range": [
+      455,
+      456
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 15
+      },
+      "end": {
+        "line": 13,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/g/",
+    "regex": {
+      "pattern": "g",
+      "flags": ""
+    },
+    "range": [
+      456,
+      459
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 16
+      },
+      "end": {
+        "line": 13,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      459,
+      460
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 19
+      },
+      "end": {
+        "line": 13,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "source",
+    "range": [
+      460,
+      466
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 20
+      },
+      "end": {
+        "line": 13,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      466,
+      467
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 26
+      },
+      "end": {
+        "line": 13,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "o2",
+    "range": [
+      468,
+      470
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 28
+      },
+      "end": {
+        "line": 13,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      471,
+      472
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 31
+      },
+      "end": {
+        "line": 13,
+        "column": 32
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n2",
+    "range": [
+      473,
+      475
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 33
+      },
+      "end": {
+        "line": 13,
+        "column": 35
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "--",
+    "range": [
+      475,
+      477
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 35
+      },
+      "end": {
+        "line": 13,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "-",
+    "range": [
+      477,
+      478
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 37
+      },
+      "end": {
+        "line": 13,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/s/",
+    "regex": {
+      "pattern": "s",
+      "flags": ""
+    },
+    "range": [
+      478,
+      481
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 38
+      },
+      "end": {
+        "line": 13,
+        "column": 41
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      481,
+      482
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 41
+      },
+      "end": {
+        "line": 13,
+        "column": 42
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "source",
+    "range": [
+      482,
+      488
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 42
+      },
+      "end": {
+        "line": 13,
+        "column": 48
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      488,
+      489
+    ],
+    "loc": {
+      "start": {
+        "line": 13,
+        "column": 48
+      },
+      "end": {
+        "line": 13,
+        "column": 49
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      491,
+      496
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 0
+      },
+      "end": {
+        "line": 15,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "re1",
+    "range": [
+      497,
+      500
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 6
+      },
+      "end": {
+        "line": 15,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      501,
+      502
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 10
+      },
+      "end": {
+        "line": 15,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/=/g",
+    "regex": {
+      "pattern": "=",
+      "flags": "g"
+    },
+    "range": [
+      503,
+      507
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 12
+      },
+      "end": {
+        "line": 15,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      507,
+      508
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 16
+      },
+      "end": {
+        "line": 15,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      509,
+      514
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 0
+      },
+      "end": {
+        "line": 16,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "re2",
+    "range": [
+      515,
+      518
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 6
+      },
+      "end": {
+        "line": 16,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      519,
+      520
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 10
+      },
+      "end": {
+        "line": 16,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/a\\/b\\/c/gimsu",
+    "regex": {
+      "pattern": "a\\/b\\/c",
+      "flags": "gimsu"
+    },
+    "range": [
+      521,
+      535
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 12
+      },
+      "end": {
+        "line": 16,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      535,
+      536
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 26
+      },
+      "end": {
+        "line": 16,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      537,
+      542
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 0
+      },
+      "end": {
+        "line": 17,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "re3",
+    "range": [
+      543,
+      546
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 6
+      },
+      "end": {
+        "line": 17,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      547,
+      548
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 10
+      },
+      "end": {
+        "line": 17,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      549,
+      550
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 12
+      },
+      "end": {
+        "line": 17,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ">",
+    "range": [
+      551,
+      552
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 14
+      },
+      "end": {
+        "line": 17,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      553,
+      554
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 16
+      },
+      "end": {
+        "line": 17,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "?",
+    "range": [
+      555,
+      556
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 18
+      },
+      "end": {
+        "line": 17,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/^\\d+$/",
+    "regex": {
+      "pattern": "^\\d+$",
+      "flags": ""
+    },
+    "range": [
+      557,
+      564
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 20
+      },
+      "end": {
+        "line": 17,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      565,
+      566
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 28
+      },
+      "end": {
+        "line": 17,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/x/y",
+    "regex": {
+      "pattern": "x",
+      "flags": "y"
+    },
+    "range": [
+      567,
+      571
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 30
+      },
+      "end": {
+        "line": 17,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      571,
+      572
+    ],
+    "loc": {
+      "start": {
+        "line": 17,
+        "column": 34
+      },
+      "end": {
+        "line": 17,
+        "column": 35
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      573,
+      578
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 0
+      },
+      "end": {
+        "line": 18,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "re4",
+    "range": [
+      579,
+      582
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 6
+      },
+      "end": {
+        "line": 18,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      583,
+      584
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 10
+      },
+      "end": {
+        "line": 18,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "[",
+    "range": [
+      585,
+      586
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 12
+      },
+      "end": {
+        "line": 18,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/g/",
+    "regex": {
+      "pattern": "g",
+      "flags": ""
+    },
+    "range": [
+      586,
+      589
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 13
+      },
+      "end": {
+        "line": 18,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      589,
+      590
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 16
+      },
+      "end": {
+        "line": 18,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/i/m",
+    "regex": {
+      "pattern": "i",
+      "flags": "m"
+    },
+    "range": [
+      591,
+      595
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 18
+      },
+      "end": {
+        "line": 18,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      595,
+      596
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 22
+      },
+      "end": {
+        "line": 18,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/s/u",
+    "regex": {
+      "pattern": "s",
+      "flags": "u"
+    },
+    "range": [
+      597,
+      601
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 24
+      },
+      "end": {
+        "line": 18,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]",
+    "range": [
+      601,
+      602
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 28
+      },
+      "end": {
+        "line": 18,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      602,
+      603
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 29
+      },
+      "end": {
+        "line": 18,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      604,
+      609
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 0
+      },
+      "end": {
+        "line": 19,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "re5",
+    "range": [
+      610,
+      613
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 6
+      },
+      "end": {
+        "line": 19,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      614,
+      615
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 10
+      },
+      "end": {
+        "line": 19,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      616,
+      617
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 12
+      },
+      "end": {
+        "line": 19,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "p",
+    "range": [
+      618,
+      619
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 14
+      },
+      "end": {
+        "line": 19,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      619,
+      620
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 15
+      },
+      "end": {
+        "line": 19,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/v/",
+    "regex": {
+      "pattern": "v",
+      "flags": ""
+    },
+    "range": [
+      621,
+      624
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 17
+      },
+      "end": {
+        "line": 19,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      624,
+      625
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 20
+      },
+      "end": {
+        "line": 19,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "q",
+    "range": [
+      626,
+      627
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 22
+      },
+      "end": {
+        "line": 19,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      627,
+      628
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 23
+      },
+      "end": {
+        "line": 19,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "d",
+    "range": [
+      629,
+      630
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 25
+      },
+      "end": {
+        "line": 19,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      630,
+      631
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 26
+      },
+      "end": {
+        "line": 19,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      631,
+      632
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 27
+      },
+      "end": {
+        "line": 19,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      632,
+      633
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 28
+      },
+      "end": {
+        "line": 19,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      633,
+      634
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 29
+      },
+      "end": {
+        "line": 19,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      635,
+      636
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 31
+      },
+      "end": {
+        "line": 19,
+        "column": 32
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      636,
+      637
+    ],
+    "loc": {
+      "start": {
+        "line": 19,
+        "column": 32
+      },
+      "end": {
+        "line": 19,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      638,
+      643
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 0
+      },
+      "end": {
+        "line": 20,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "w",
+    "range": [
+      644,
+      645
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 6
+      },
+      "end": {
+        "line": 20,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      646,
+      647
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 8
+      },
+      "end": {
+        "line": 20,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "typeof",
+    "range": [
+      648,
+      654
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 10
+      },
+      "end": {
+        "line": 20,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/re/",
+    "regex": {
+      "pattern": "re",
+      "flags": ""
+    },
+    "range": [
+      655,
+      659
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 17
+      },
+      "end": {
+        "line": 20,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "===",
+    "range": [
+      660,
+      663
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 22
+      },
+      "end": {
+        "line": 20,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'object'",
+    "range": [
+      664,
+      672
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 26
+      },
+      "end": {
+        "line": 20,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "?",
+    "range": [
+      673,
+      674
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 35
+      },
+      "end": {
+        "line": 20,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "d",
+    "range": [
+      675,
+      676
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 37
+      },
+      "end": {
+        "line": 20,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      676,
+      677
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 38
+      },
+      "end": {
+        "line": 20,
+        "column": 39
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      677,
+      678
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 39
+      },
+      "end": {
+        "line": 20,
+        "column": 40
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      679,
+      680
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 41
+      },
+      "end": {
+        "line": 20,
+        "column": 42
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      681,
+      682
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 43
+      },
+      "end": {
+        "line": 20,
+        "column": 44
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      682,
+      683
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 44
+      },
+      "end": {
+        "line": 20,
+        "column": 45
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "d",
+    "range": [
+      683,
+      684
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 45
+      },
+      "end": {
+        "line": 20,
+        "column": 46
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      684,
+      685
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 46
+      },
+      "end": {
+        "line": 20,
+        "column": 47
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "function",
+    "range": [
+      687,
+      695
+    ],
+    "loc": {
+      "start": {
+        "line": 22,
+        "column": 0
+      },
+      "end": {
+        "line": 22,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "fn1",
+    "range": [
+      696,
+      699
+    ],
+    "loc": {
+      "start": {
+        "line": 22,
+        "column": 9
+      },
+      "end": {
+        "line": 22,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      699,
+      700
+    ],
+    "loc": {
+      "start": {
+        "line": 22,
+        "column": 12
+      },
+      "end": {
+        "line": 22,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      700,
+      701
+    ],
+    "loc": {
+      "start": {
+        "line": 22,
+        "column": 13
+      },
+      "end": {
+        "line": 22,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      701,
+      702
+    ],
+    "loc": {
+      "start": {
+        "line": 22,
+        "column": 14
+      },
+      "end": {
+        "line": 22,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      703,
+      704
+    ],
+    "loc": {
+      "start": {
+        "line": 22,
+        "column": 16
+      },
+      "end": {
+        "line": 22,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "if",
+    "range": [
+      707,
+      709
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 2
+      },
+      "end": {
+        "line": 23,
+        "column": 4
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      710,
+      711
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 5
+      },
+      "end": {
+        "line": 23,
+        "column": 6
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      711,
+      712
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 6
+      },
+      "end": {
+        "line": 23,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      712,
+      713
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 7
+      },
+      "end": {
+        "line": 23,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "return",
+    "range": [
+      714,
+      720
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 9
+      },
+      "end": {
+        "line": 23,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/a/",
+    "regex": {
+      "pattern": "a",
+      "flags": ""
+    },
+    "range": [
+      721,
+      724
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 16
+      },
+      "end": {
+        "line": 23,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      724,
+      725
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 19
+      },
+      "end": {
+        "line": 23,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "test",
+    "range": [
+      725,
+      729
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 20
+      },
+      "end": {
+        "line": 23,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      729,
+      730
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 24
+      },
+      "end": {
+        "line": 23,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "String",
+    "range": [
+      730,
+      736
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 25
+      },
+      "end": {
+        "line": 23,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      736,
+      737
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 31
+      },
+      "end": {
+        "line": 23,
+        "column": 32
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      737,
+      738
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 32
+      },
+      "end": {
+        "line": 23,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      738,
+      739
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 33
+      },
+      "end": {
+        "line": 23,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      739,
+      740
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 34
+      },
+      "end": {
+        "line": 23,
+        "column": 35
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "?",
+    "range": [
+      741,
+      742
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 36
+      },
+      "end": {
+        "line": 23,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      743,
+      744
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 38
+      },
+      "end": {
+        "line": 23,
+        "column": 39
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      744,
+      745
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 39
+      },
+      "end": {
+        "line": 23,
+        "column": 40
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      745,
+      746
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 40
+      },
+      "end": {
+        "line": 23,
+        "column": 41
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      746,
+      747
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 41
+      },
+      "end": {
+        "line": 23,
+        "column": 42
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      747,
+      748
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 42
+      },
+      "end": {
+        "line": 23,
+        "column": 43
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      749,
+      750
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 44
+      },
+      "end": {
+        "line": 23,
+        "column": 45
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "-",
+    "range": [
+      751,
+      752
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 46
+      },
+      "end": {
+        "line": 23,
+        "column": 47
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      752,
+      753
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 47
+      },
+      "end": {
+        "line": 23,
+        "column": 48
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      753,
+      754
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 48
+      },
+      "end": {
+        "line": 23,
+        "column": 49
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "y",
+    "range": [
+      754,
+      755
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 49
+      },
+      "end": {
+        "line": 23,
+        "column": 50
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      755,
+      756
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 50
+      },
+      "end": {
+        "line": 23,
+        "column": 51
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "d",
+    "range": [
+      756,
+      757
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 51
+      },
+      "end": {
+        "line": 23,
+        "column": 52
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      757,
+      758
+    ],
+    "loc": {
+      "start": {
+        "line": 23,
+        "column": 52
+      },
+      "end": {
+        "line": 23,
+        "column": 53
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "switch",
+    "range": [
+      761,
+      767
+    ],
+    "loc": {
+      "start": {
+        "line": 24,
+        "column": 2
+      },
+      "end": {
+        "line": 24,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      768,
+      769
+    ],
+    "loc": {
+      "start": {
+        "line": 24,
+        "column": 9
+      },
+      "end": {
+        "line": 24,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      769,
+      770
+    ],
+    "loc": {
+      "start": {
+        "line": 24,
+        "column": 10
+      },
+      "end": {
+        "line": 24,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      770,
+      771
+    ],
+    "loc": {
+      "start": {
+        "line": 24,
+        "column": 11
+      },
+      "end": {
+        "line": 24,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      772,
+      773
+    ],
+    "loc": {
+      "start": {
+        "line": 24,
+        "column": 13
+      },
+      "end": {
+        "line": 24,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "case",
+    "range": [
+      778,
+      782
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 4
+      },
+      "end": {
+        "line": 25,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      783,
+      784
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 9
+      },
+      "end": {
+        "line": 25,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      784,
+      785
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 10
+      },
+      "end": {
+        "line": 25,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "return",
+    "range": [
+      786,
+      792
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 12
+      },
+      "end": {
+        "line": 25,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/b/",
+    "regex": {
+      "pattern": "b",
+      "flags": ""
+    },
+    "range": [
+      793,
+      796
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 19
+      },
+      "end": {
+        "line": 25,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      796,
+      797
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 22
+      },
+      "end": {
+        "line": 25,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "source",
+    "range": [
+      797,
+      803
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 23
+      },
+      "end": {
+        "line": 25,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      803,
+      804
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 29
+      },
+      "end": {
+        "line": 25,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "length",
+    "range": [
+      804,
+      810
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 30
+      },
+      "end": {
+        "line": 25,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      810,
+      811
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 36
+      },
+      "end": {
+        "line": 25,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      811,
+      812
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 37
+      },
+      "end": {
+        "line": 25,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      812,
+      813
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 38
+      },
+      "end": {
+        "line": 25,
+        "column": 39
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      813,
+      814
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 39
+      },
+      "end": {
+        "line": 25,
+        "column": 40
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      814,
+      815
+    ],
+    "loc": {
+      "start": {
+        "line": 25,
+        "column": 40
+      },
+      "end": {
+        "line": 25,
+        "column": 41
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      818,
+      819
+    ],
+    "loc": {
+      "start": {
+        "line": 26,
+        "column": 2
+      },
+      "end": {
+        "line": 26,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "return",
+    "range": [
+      822,
+      828
+    ],
+    "loc": {
+      "start": {
+        "line": 27,
+        "column": 2
+      },
+      "end": {
+        "line": 27,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      829,
+      830
+    ],
+    "loc": {
+      "start": {
+        "line": 27,
+        "column": 9
+      },
+      "end": {
+        "line": 27,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      830,
+      831
+    ],
+    "loc": {
+      "start": {
+        "line": 27,
+        "column": 10
+      },
+      "end": {
+        "line": 27,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "y",
+    "range": [
+      831,
+      832
+    ],
+    "loc": {
+      "start": {
+        "line": 27,
+        "column": 11
+      },
+      "end": {
+        "line": 27,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      832,
+      833
+    ],
+    "loc": {
+      "start": {
+        "line": 27,
+        "column": 12
+      },
+      "end": {
+        "line": 27,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "d",
+    "range": [
+      833,
+      834
+    ],
+    "loc": {
+      "start": {
+        "line": 27,
+        "column": 13
+      },
+      "end": {
+        "line": 27,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      834,
+      835
+    ],
+    "loc": {
+      "start": {
+        "line": 27,
+        "column": 14
+      },
+      "end": {
+        "line": 27,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      836,
+      837
+    ],
+    "loc": {
+      "start": {
+        "line": 28,
+        "column": 0
+      },
+      "end": {
+        "line": 28,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      839,
+      844
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 0
+      },
+      "end": {
+        "line": 30,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "res",
+    "range": [
+      845,
+      848
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 6
+      },
+      "end": {
+        "line": 30,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      849,
+      850
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 10
+      },
+      "end": {
+        "line": 30,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "fn1",
+    "range": [
+      851,
+      854
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 12
+      },
+      "end": {
+        "line": 30,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      854,
+      855
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 15
+      },
+      "end": {
+        "line": 30,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      855,
+      856
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 16
+      },
+      "end": {
+        "line": 30,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      856,
+      857
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 17
+      },
+      "end": {
+        "line": 30,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "+",
+    "range": [
+      858,
+      859
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 19
+      },
+      "end": {
+        "line": 30,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "fn1",
+    "range": [
+      860,
+      863
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 21
+      },
+      "end": {
+        "line": 30,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      863,
+      864
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 24
+      },
+      "end": {
+        "line": 30,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "1",
+    "range": [
+      864,
+      865
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 25
+      },
+      "end": {
+        "line": 30,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      865,
+      866
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 26
+      },
+      "end": {
+        "line": 30,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "+",
+    "range": [
+      867,
+      868
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 28
+      },
+      "end": {
+        "line": 30,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "fn1",
+    "range": [
+      869,
+      872
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 30
+      },
+      "end": {
+        "line": 30,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      872,
+      873
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 33
+      },
+      "end": {
+        "line": 30,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "-",
+    "range": [
+      873,
+      874
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 34
+      },
+      "end": {
+        "line": 30,
+        "column": 35
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "1",
+    "range": [
+      874,
+      875
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 35
+      },
+      "end": {
+        "line": 30,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      875,
+      876
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 36
+      },
+      "end": {
+        "line": 30,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      876,
+      877
+    ],
+    "loc": {
+      "start": {
+        "line": 30,
+        "column": 37
+      },
+      "end": {
+        "line": 30,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      878,
+      883
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 0
+      },
+      "end": {
+        "line": 31,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "fn2",
+    "range": [
+      884,
+      887
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 6
+      },
+      "end": {
+        "line": 31,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      888,
+      889
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 10
+      },
+      "end": {
+        "line": 31,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      890,
+      891
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 12
+      },
+      "end": {
+        "line": 31,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      891,
+      892
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 13
+      },
+      "end": {
+        "line": 31,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      892,
+      893
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 14
+      },
+      "end": {
+        "line": 31,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=>",
+    "range": [
+      894,
+      896
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 16
+      },
+      "end": {
+        "line": 31,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      897,
+      898
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 19
+      },
+      "end": {
+        "line": 31,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ">",
+    "range": [
+      899,
+      900
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 21
+      },
+      "end": {
+        "line": 31,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      901,
+      902
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 23
+      },
+      "end": {
+        "line": 31,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "?",
+    "range": [
+      903,
+      904
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 25
+      },
+      "end": {
+        "line": 31,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      905,
+      906
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 27
+      },
+      "end": {
+        "line": 31,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      906,
+      907
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 28
+      },
+      "end": {
+        "line": 31,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      907,
+      908
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 29
+      },
+      "end": {
+        "line": 31,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      908,
+      909
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 30
+      },
+      "end": {
+        "line": 31,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      909,
+      910
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 31
+      },
+      "end": {
+        "line": 31,
+        "column": 32
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      911,
+      912
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 33
+      },
+      "end": {
+        "line": 31,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/c/",
+    "regex": {
+      "pattern": "c",
+      "flags": ""
+    },
+    "range": [
+      913,
+      916
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 35
+      },
+      "end": {
+        "line": 31,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      916,
+      917
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 38
+      },
+      "end": {
+        "line": 31,
+        "column": 39
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "test",
+    "range": [
+      917,
+      921
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 39
+      },
+      "end": {
+        "line": 31,
+        "column": 43
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      921,
+      922
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 43
+      },
+      "end": {
+        "line": 31,
+        "column": 44
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "String",
+    "range": [
+      922,
+      928
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 44
+      },
+      "end": {
+        "line": 31,
+        "column": 50
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      928,
+      929
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 50
+      },
+      "end": {
+        "line": 31,
+        "column": 51
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      929,
+      930
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 51
+      },
+      "end": {
+        "line": 31,
+        "column": 52
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      930,
+      931
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 52
+      },
+      "end": {
+        "line": 31,
+        "column": 53
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      931,
+      932
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 53
+      },
+      "end": {
+        "line": 31,
+        "column": 54
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      932,
+      933
+    ],
+    "loc": {
+      "start": {
+        "line": 31,
+        "column": 54
+      },
+      "end": {
+        "line": 31,
+        "column": 55
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      976,
+      981
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 0
+      },
+      "end": {
+        "line": 34,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "t1",
+    "range": [
+      982,
+      984
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 6
+      },
+      "end": {
+        "line": 34,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      985,
+      986
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 9
+      },
+      "end": {
+        "line": 34,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Template",
+    "value": "`n=${",
+    "range": [
+      987,
+      992
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 11
+      },
+      "end": {
+        "line": 34,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/\\d+/",
+    "regex": {
+      "pattern": "\\d+",
+      "flags": ""
+    },
+    "range": [
+      992,
+      997
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 16
+      },
+      "end": {
+        "line": 34,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      997,
+      998
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 21
+      },
+      "end": {
+        "line": 34,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "source",
+    "range": [
+      998,
+      1004
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 22
+      },
+      "end": {
+        "line": 34,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Template",
+    "value": "}`",
+    "range": [
+      1004,
+      1006
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 28
+      },
+      "end": {
+        "line": 34,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      1006,
+      1007
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 30
+      },
+      "end": {
+        "line": 34,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "t2",
+    "range": [
+      1008,
+      1010
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 32
+      },
+      "end": {
+        "line": 34,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      1011,
+      1012
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 35
+      },
+      "end": {
+        "line": 34,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Template",
+    "value": "`${",
+    "range": [
+      1013,
+      1016
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 37
+      },
+      "end": {
+        "line": 34,
+        "column": 40
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "q",
+    "range": [
+      1016,
+      1017
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 40
+      },
+      "end": {
+        "line": 34,
+        "column": 41
+      }
+    }
+  },
+  {
+    "type": "Template",
+    "value": "}`",
+    "range": [
+      1017,
+      1019
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 41
+      },
+      "end": {
+        "line": 34,
+        "column": 43
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      1019,
+      1020
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 43
+      },
+      "end": {
+        "line": 34,
+        "column": 44
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "length",
+    "range": [
+      1020,
+      1026
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 44
+      },
+      "end": {
+        "line": 34,
+        "column": 50
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      1026,
+      1027
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 50
+      },
+      "end": {
+        "line": 34,
+        "column": 51
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "g",
+    "range": [
+      1027,
+      1028
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 51
+      },
+      "end": {
+        "line": 34,
+        "column": 52
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "/",
+    "range": [
+      1028,
+      1029
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 52
+      },
+      "end": {
+        "line": 34,
+        "column": 53
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "i",
+    "range": [
+      1029,
+      1030
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 53
+      },
+      "end": {
+        "line": 34,
+        "column": 54
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      1030,
+      1031
+    ],
+    "loc": {
+      "start": {
+        "line": 34,
+        "column": 54
+      },
+      "end": {
+        "line": 34,
+        "column": 55
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      1032,
+      1037
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 0
+      },
+      "end": {
+        "line": 35,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "t3",
+    "range": [
+      1038,
+      1040
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 6
+      },
+      "end": {
+        "line": 35,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      1041,
+      1042
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 9
+      },
+      "end": {
+        "line": 35,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "void",
+    "range": [
+      1043,
+      1047
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 11
+      },
+      "end": {
+        "line": 35,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/gi/",
+    "regex": {
+      "pattern": "gi",
+      "flags": ""
+    },
+    "range": [
+      1048,
+      1052
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 16
+      },
+      "end": {
+        "line": 35,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      1052,
+      1053
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 20
+      },
+      "end": {
+        "line": 35,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "source",
+    "range": [
+      1053,
+      1059
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 21
+      },
+      "end": {
+        "line": 35,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      1059,
+      1060
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 27
+      },
+      "end": {
+        "line": 35,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "t4",
+    "range": [
+      1061,
+      1063
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 29
+      },
+      "end": {
+        "line": 35,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      1064,
+      1065
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 32
+      },
+      "end": {
+        "line": 35,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "p",
+    "range": [
+      1066,
+      1067
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 34
+      },
+      "end": {
+        "line": 35,
+        "column": 35
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "instanceof",
+    "range": [
+      1068,
+      1078
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 36
+      },
+      "end": {
+        "line": 35,
+        "column": 46
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "RegExp",
+    "range": [
+      1079,
+      1085
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 47
+      },
+      "end": {
+        "line": 35,
+        "column": 53
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "?",
+    "range": [
+      1086,
+      1087
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 54
+      },
+      "end": {
+        "line": 35,
+        "column": 55
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "p",
+    "range": [
+      1088,
+      1089
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 56
+      },
+      "end": {
+        "line": 35,
+        "column": 57
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      1089,
+      1090
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 57
+      },
+      "end": {
+        "line": 35,
+        "column": 58
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "flags",
+    "range": [
+      1090,
+      1095
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 58
+      },
+      "end": {
+        "line": 35,
+        "column": 63
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      1096,
+      1097
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 64
+      },
+      "end": {
+        "line": 35,
+        "column": 65
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/m/g",
+    "regex": {
+      "pattern": "m",
+      "flags": "g"
+    },
+    "range": [
+      1098,
+      1102
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 66
+      },
+      "end": {
+        "line": 35,
+        "column": 70
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      1102,
+      1103
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 70
+      },
+      "end": {
+        "line": 35,
+        "column": 71
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "source",
+    "range": [
+      1103,
+      1109
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 71
+      },
+      "end": {
+        "line": 35,
+        "column": 77
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      1109,
+      1110
+    ],
+    "loc": {
+      "start": {
+        "line": 35,
+        "column": 77
+      },
+      "end": {
+        "line": 35,
+        "column": 78
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      1112,
+      1113
+    ],
+    "loc": {
+      "start": {
+        "line": 37,
+        "column": 0
+      },
+      "end": {
+        "line": 37,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      1145,
+      1146
+    ],
+    "loc": {
+      "start": {
+        "line": 37,
+        "column": 33
+      },
+      "end": {
+        "line": 37,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/start/",
+    "regex": {
+      "pattern": "start",
+      "flags": ""
+    },
+    "range": [
+      1147,
+      1154
+    ],
+    "loc": {
+      "start": {
+        "line": 38,
+        "column": 0
+      },
+      "end": {
+        "line": 38,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      1154,
+      1155
+    ],
+    "loc": {
+      "start": {
+        "line": 38,
+        "column": 7
+      },
+      "end": {
+        "line": 38,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "test",
+    "range": [
+      1155,
+      1159
+    ],
+    "loc": {
+      "start": {
+        "line": 38,
+        "column": 8
+      },
+      "end": {
+        "line": 38,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      1159,
+      1160
+    ],
+    "loc": {
+      "start": {
+        "line": 38,
+        "column": 12
+      },
+      "end": {
+        "line": 38,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'line start'",
+    "range": [
+      1160,
+      1172
+    ],
+    "loc": {
+      "start": {
+        "line": 38,
+        "column": 13
+      },
+      "end": {
+        "line": 38,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      1172,
+      1173
+    ],
+    "loc": {
+      "start": {
+        "line": 38,
+        "column": 25
+      },
+      "end": {
+        "line": 38,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      1173,
+      1174
+    ],
+    "loc": {
+      "start": {
+        "line": 38,
+        "column": 26
+      },
+      "end": {
+        "line": 38,
+        "column": 27
+      }
+    }
+  }
+]

--- a/tests/fixtures/test-0385.js
+++ b/tests/fixtures/test-0385.js
@@ -1,0 +1,38 @@
+const d = 8, g = 4, i = 2, m = 16, s = 3, u = 6, v = 9, y = 5;
+let p = 10, q = 12;
+
+const a = d/g/i, b = m/s/u, c = v/y/d/g;
+const e = (d)/g/i, f = [m][0]/s/u, h = i.valueOf()/g/i;
+
+// Tests for `++` / `--` followed by a `/` division operators
+const j = --p/s/u, k = ++q/y/d, l = p++/g/i, x = q--/s/u;
+
+let n1 = 1, n2 = 9;
+// `+++` / `---` should be split into `++ +` / `-- -`
+// `n1+++/g/` is parsed as `n1 ++ + /g/` (regex, not division)
+const o1 = n1+++/g/.source, o2 = n2---/s/.source;
+
+const re1 = /=/g;
+const re2 = /a\/b\/c/gimsu;
+const re3 = i > 0 ? /^\d+$/ : /x/y;
+const re4 = [/g/, /i/m, /s/u];
+const re5 = { p: /v/, q: d/g/i };
+const w = typeof /re/ === 'object' ? d/g : g/d;
+
+function fn1(n) {
+  if (n) return /a/.test(String(n)) ? n/g/i : -n/y/d;
+  switch (n) {
+    case 0: return /b/.source.length/g/i;
+  }
+  return n/y/d;
+}
+
+const res = fn1(0) + fn1(1) + fn1(-1);
+const fn2 = (n) => n > 0 ? n/g/i : /c/.test(String(n));
+
+// Tests for Template literals and regex
+const t1 = `n=${/\d+/.source}`, t2 = `${q}`.length/g/i;
+const t3 = void /gi/.source, t4 = p instanceof RegExp ? p.flags : /m/g.source;
+
+{ /* BlockStatement and regex */ }
+/start/.test('line start');

--- a/tests/fixtures/test-0386-parse-expected.json
+++ b/tests/fixtures/test-0386-parse-expected.json
@@ -1,0 +1,994 @@
+{
+  "range": [
+    0,
+    158
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 10,
+      "column": 19
+    }
+  },
+  "type": "Program",
+  "body": [
+    {
+      "range": [
+        0,
+        37
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 37
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            6,
+            36
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 6
+            },
+            "end": {
+              "line": 1,
+              "column": 36
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              6,
+              9
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 6
+              },
+              "end": {
+                "line": 1,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "obj"
+          },
+          "init": {
+            "range": [
+              12,
+              36
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 12
+              },
+              "end": {
+                "line": 1,
+                "column": 36
+              }
+            },
+            "type": "ObjectExpression",
+            "properties": [
+              {
+                "range": [
+                  14,
+                  19
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 19
+                  }
+                },
+                "type": "Property",
+                "key": {
+                  "range": [
+                    14,
+                    15
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 15
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "s"
+                },
+                "computed": false,
+                "value": {
+                  "range": [
+                    17,
+                    19
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 19
+                    }
+                  },
+                  "type": "Literal",
+                  "value": "",
+                  "raw": "''"
+                },
+                "kind": "init",
+                "method": false,
+                "shorthand": false
+              },
+              {
+                "range": [
+                  21,
+                  25
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 25
+                  }
+                },
+                "type": "Property",
+                "key": {
+                  "range": [
+                    21,
+                    22
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 21
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 22
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "n"
+                },
+                "computed": false,
+                "value": {
+                  "range": [
+                    24,
+                    25
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 24
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 25
+                    }
+                  },
+                  "type": "Literal",
+                  "value": 0,
+                  "raw": "0"
+                },
+                "kind": "init",
+                "method": false,
+                "shorthand": false
+              },
+              {
+                "range": [
+                  27,
+                  34
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 27
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 34
+                  }
+                },
+                "type": "Property",
+                "key": {
+                  "range": [
+                    27,
+                    28
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 27
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 28
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "a"
+                },
+                "computed": false,
+                "value": {
+                  "range": [
+                    30,
+                    34
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 30
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 34
+                    }
+                  },
+                  "type": "Literal",
+                  "value": null,
+                  "raw": "null"
+                },
+                "kind": "init",
+                "method": false,
+                "shorthand": false
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        38,
+        64
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 26
+        }
+      },
+      "type": "ExpressionStatement",
+      "expression": {
+        "range": [
+          38,
+          63
+        ],
+        "loc": {
+          "start": {
+            "line": 2,
+            "column": 0
+          },
+          "end": {
+            "line": 2,
+            "column": 25
+          }
+        },
+        "type": "AssignmentExpression",
+        "operator": "||=",
+        "left": {
+          "range": [
+            38,
+            43
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 5
+            }
+          },
+          "type": "MemberExpression",
+          "computed": false,
+          "optional": false,
+          "object": {
+            "range": [
+              38,
+              41
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 0
+              },
+              "end": {
+                "line": 2,
+                "column": 3
+              }
+            },
+            "type": "Identifier",
+            "name": "obj"
+          },
+          "property": {
+            "range": [
+              42,
+              43
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 4
+              },
+              "end": {
+                "line": 2,
+                "column": 5
+              }
+            },
+            "type": "Identifier",
+            "name": "s"
+          }
+        },
+        "right": {
+          "range": [
+            48,
+            63
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 10
+            },
+            "end": {
+              "line": 2,
+              "column": 25
+            }
+          },
+          "type": "Literal",
+          "value": "default value",
+          "raw": "'default value'"
+        }
+      }
+    },
+    {
+      "range": [
+        65,
+        85
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 20
+        }
+      },
+      "type": "ExpressionStatement",
+      "expression": {
+        "range": [
+          65,
+          84
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 19
+          }
+        },
+        "type": "AssignmentExpression",
+        "operator": "&&=",
+        "left": {
+          "range": [
+            65,
+            70
+          ],
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 0
+            },
+            "end": {
+              "line": 3,
+              "column": 5
+            }
+          },
+          "type": "MemberExpression",
+          "computed": false,
+          "optional": false,
+          "object": {
+            "range": [
+              65,
+              68
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 0
+              },
+              "end": {
+                "line": 3,
+                "column": 3
+              }
+            },
+            "type": "Identifier",
+            "name": "obj"
+          },
+          "property": {
+            "range": [
+              69,
+              70
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 4
+              },
+              "end": {
+                "line": 3,
+                "column": 5
+              }
+            },
+            "type": "Identifier",
+            "name": "n"
+          }
+        },
+        "right": {
+          "range": [
+            75,
+            84
+          ],
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 10
+            },
+            "end": {
+              "line": 3,
+              "column": 19
+            }
+          },
+          "type": "BinaryExpression",
+          "operator": "*",
+          "left": {
+            "range": [
+              75,
+              80
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 10
+              },
+              "end": {
+                "line": 3,
+                "column": 15
+              }
+            },
+            "type": "MemberExpression",
+            "computed": false,
+            "optional": false,
+            "object": {
+              "range": [
+                75,
+                78
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 10
+                },
+                "end": {
+                  "line": 3,
+                  "column": 13
+                }
+              },
+              "type": "Identifier",
+              "name": "obj"
+            },
+            "property": {
+              "range": [
+                79,
+                80
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 14
+                },
+                "end": {
+                  "line": 3,
+                  "column": 15
+                }
+              },
+              "type": "Identifier",
+              "name": "n"
+            }
+          },
+          "right": {
+            "range": [
+              83,
+              84
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 18
+              },
+              "end": {
+                "line": 3,
+                "column": 19
+              }
+            },
+            "type": "Literal",
+            "value": 2,
+            "raw": "2"
+          }
+        }
+      }
+    },
+    {
+      "range": [
+        86,
+        99
+      ],
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 13
+        }
+      },
+      "type": "ExpressionStatement",
+      "expression": {
+        "range": [
+          86,
+          98
+        ],
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 0
+          },
+          "end": {
+            "line": 4,
+            "column": 12
+          }
+        },
+        "type": "AssignmentExpression",
+        "operator": "??=",
+        "left": {
+          "range": [
+            86,
+            91
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 0
+            },
+            "end": {
+              "line": 4,
+              "column": 5
+            }
+          },
+          "type": "MemberExpression",
+          "computed": false,
+          "optional": false,
+          "object": {
+            "range": [
+              86,
+              89
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 0
+              },
+              "end": {
+                "line": 4,
+                "column": 3
+              }
+            },
+            "type": "Identifier",
+            "name": "obj"
+          },
+          "property": {
+            "range": [
+              90,
+              91
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 4
+              },
+              "end": {
+                "line": 4,
+                "column": 5
+              }
+            },
+            "type": "Identifier",
+            "name": "a"
+          }
+        },
+        "right": {
+          "range": [
+            96,
+            98
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 10
+            },
+            "end": {
+              "line": 4,
+              "column": 12
+            }
+          },
+          "type": "ArrayExpression",
+          "elements": []
+        }
+      }
+    },
+    {
+      "range": [
+        101,
+        111
+      ],
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 0
+        },
+        "end": {
+          "line": 6,
+          "column": 10
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            105,
+            110
+          ],
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 4
+            },
+            "end": {
+              "line": 6,
+              "column": 9
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              105,
+              106
+            ],
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 4
+              },
+              "end": {
+                "line": 6,
+                "column": 5
+              }
+            },
+            "type": "Identifier",
+            "name": "c"
+          },
+          "init": {
+            "range": [
+              109,
+              110
+            ],
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 8
+              },
+              "end": {
+                "line": 6,
+                "column": 9
+              }
+            },
+            "type": "Literal",
+            "value": 0,
+            "raw": "0"
+          }
+        }
+      ],
+      "kind": "let"
+    },
+    {
+      "range": [
+        112,
+        120
+      ],
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 8
+        }
+      },
+      "type": "ExpressionStatement",
+      "expression": {
+        "range": [
+          112,
+          119
+        ],
+        "loc": {
+          "start": {
+            "line": 7,
+            "column": 0
+          },
+          "end": {
+            "line": 7,
+            "column": 7
+          }
+        },
+        "type": "AssignmentExpression",
+        "operator": "||=",
+        "left": {
+          "range": [
+            112,
+            113
+          ],
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 0
+            },
+            "end": {
+              "line": 7,
+              "column": 1
+            }
+          },
+          "type": "Identifier",
+          "name": "c"
+        },
+        "right": {
+          "range": [
+            118,
+            119
+          ],
+          "loc": {
+            "start": {
+              "line": 7,
+              "column": 6
+            },
+            "end": {
+              "line": 7,
+              "column": 7
+            }
+          },
+          "type": "Literal",
+          "value": 3,
+          "raw": "3"
+        }
+      }
+    },
+    {
+      "range": [
+        122,
+        138
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 0
+        },
+        "end": {
+          "line": 9,
+          "column": 16
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            128,
+            137
+          ],
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 6
+            },
+            "end": {
+              "line": 9,
+              "column": 15
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              128,
+              132
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 6
+              },
+              "end": {
+                "line": 9,
+                "column": 10
+              }
+            },
+            "type": "Identifier",
+            "name": "obj2"
+          },
+          "init": {
+            "range": [
+              135,
+              137
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 13
+              },
+              "end": {
+                "line": 9,
+                "column": 15
+              }
+            },
+            "type": "ObjectExpression",
+            "properties": []
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        139,
+        158
+      ],
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 0
+        },
+        "end": {
+          "line": 10,
+          "column": 19
+        }
+      },
+      "type": "ExpressionStatement",
+      "expression": {
+        "range": [
+          139,
+          157
+        ],
+        "loc": {
+          "start": {
+            "line": 10,
+            "column": 0
+          },
+          "end": {
+            "line": 10,
+            "column": 18
+          }
+        },
+        "type": "AssignmentExpression",
+        "operator": "??=",
+        "left": {
+          "range": [
+            139,
+            147
+          ],
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 0
+            },
+            "end": {
+              "line": 10,
+              "column": 8
+            }
+          },
+          "type": "MemberExpression",
+          "computed": false,
+          "optional": false,
+          "object": {
+            "range": [
+              139,
+              143
+            ],
+            "loc": {
+              "start": {
+                "line": 10,
+                "column": 0
+              },
+              "end": {
+                "line": 10,
+                "column": 4
+              }
+            },
+            "type": "Identifier",
+            "name": "obj2"
+          },
+          "property": {
+            "range": [
+              144,
+              147
+            ],
+            "loc": {
+              "start": {
+                "line": 10,
+                "column": 5
+              },
+              "end": {
+                "line": 10,
+                "column": 8
+              }
+            },
+            "type": "Identifier",
+            "name": "key"
+          }
+        },
+        "right": {
+          "range": [
+            152,
+            157
+          ],
+          "loc": {
+            "start": {
+              "line": 10,
+              "column": 13
+            },
+            "end": {
+              "line": 10,
+              "column": 18
+            }
+          },
+          "type": "Literal",
+          "value": "abc",
+          "raw": "'abc'"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/test-0386-tokenize-expected.json
+++ b/tests/fixtures/test-0386-tokenize-expected.json
@@ -1,0 +1,246 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "obj"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "s"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "String",
+    "value": "''"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "a"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "Null",
+    "value": "null"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Identifier",
+    "value": "obj"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "s"
+  },
+  {
+    "type": "Punctuator",
+    "value": "||="
+  },
+  {
+    "type": "String",
+    "value": "'default value'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Identifier",
+    "value": "obj"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&="
+  },
+  {
+    "type": "Identifier",
+    "value": "obj"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": "*"
+  },
+  {
+    "type": "Numeric",
+    "value": "2"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Identifier",
+    "value": "obj"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "a"
+  },
+  {
+    "type": "Punctuator",
+    "value": "??="
+  },
+  {
+    "type": "Punctuator",
+    "value": "["
+  },
+  {
+    "type": "Punctuator",
+    "value": "]"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "let"
+  },
+  {
+    "type": "Identifier",
+    "value": "c"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Identifier",
+    "value": "c"
+  },
+  {
+    "type": "Punctuator",
+    "value": "||="
+  },
+  {
+    "type": "Numeric",
+    "value": "3"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "obj2"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Identifier",
+    "value": "obj2"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "key"
+  },
+  {
+    "type": "Punctuator",
+    "value": "??="
+  },
+  {
+    "type": "String",
+    "value": "'abc'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  }
+]

--- a/tests/fixtures/test-0386-tokenize-loc-range-expected.json
+++ b/tests/fixtures/test-0386-tokenize-loc-range-expected.json
@@ -1,0 +1,1100 @@
+[
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      0,
+      5
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "obj",
+    "range": [
+      6,
+      9
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      10,
+      11
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 10
+      },
+      "end": {
+        "line": 1,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      12,
+      13
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 12
+      },
+      "end": {
+        "line": 1,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "s",
+    "range": [
+      14,
+      15
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 14
+      },
+      "end": {
+        "line": 1,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      15,
+      16
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 15
+      },
+      "end": {
+        "line": 1,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "''",
+    "range": [
+      17,
+      19
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 17
+      },
+      "end": {
+        "line": 1,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      19,
+      20
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 19
+      },
+      "end": {
+        "line": 1,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      21,
+      22
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 21
+      },
+      "end": {
+        "line": 1,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      22,
+      23
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 22
+      },
+      "end": {
+        "line": 1,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      24,
+      25
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 24
+      },
+      "end": {
+        "line": 1,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      25,
+      26
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 25
+      },
+      "end": {
+        "line": 1,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "a",
+    "range": [
+      27,
+      28
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 27
+      },
+      "end": {
+        "line": 1,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      28,
+      29
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 28
+      },
+      "end": {
+        "line": 1,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Null",
+    "value": "null",
+    "range": [
+      30,
+      34
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 30
+      },
+      "end": {
+        "line": 1,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      35,
+      36
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 35
+      },
+      "end": {
+        "line": 1,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      36,
+      37
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 36
+      },
+      "end": {
+        "line": 1,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "obj",
+    "range": [
+      38,
+      41
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      41,
+      42
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 3
+      },
+      "end": {
+        "line": 2,
+        "column": 4
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "s",
+    "range": [
+      42,
+      43
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 4
+      },
+      "end": {
+        "line": 2,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "||=",
+    "range": [
+      44,
+      47
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 6
+      },
+      "end": {
+        "line": 2,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'default value'",
+    "range": [
+      48,
+      63
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 10
+      },
+      "end": {
+        "line": 2,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      63,
+      64
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 25
+      },
+      "end": {
+        "line": 2,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "obj",
+    "range": [
+      65,
+      68
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      68,
+      69
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 3
+      },
+      "end": {
+        "line": 3,
+        "column": 4
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      69,
+      70
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 4
+      },
+      "end": {
+        "line": 3,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&=",
+    "range": [
+      71,
+      74
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 6
+      },
+      "end": {
+        "line": 3,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "obj",
+    "range": [
+      75,
+      78
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 10
+      },
+      "end": {
+        "line": 3,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      78,
+      79
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 13
+      },
+      "end": {
+        "line": 3,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      79,
+      80
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 14
+      },
+      "end": {
+        "line": 3,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "*",
+    "range": [
+      81,
+      82
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 16
+      },
+      "end": {
+        "line": 3,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "2",
+    "range": [
+      83,
+      84
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 18
+      },
+      "end": {
+        "line": 3,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      84,
+      85
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 19
+      },
+      "end": {
+        "line": 3,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "obj",
+    "range": [
+      86,
+      89
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      89,
+      90
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 3
+      },
+      "end": {
+        "line": 4,
+        "column": 4
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "a",
+    "range": [
+      90,
+      91
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 4
+      },
+      "end": {
+        "line": 4,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "??=",
+    "range": [
+      92,
+      95
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 6
+      },
+      "end": {
+        "line": 4,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "[",
+    "range": [
+      96,
+      97
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 10
+      },
+      "end": {
+        "line": 4,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]",
+    "range": [
+      97,
+      98
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 11
+      },
+      "end": {
+        "line": 4,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      98,
+      99
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 12
+      },
+      "end": {
+        "line": 4,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "let",
+    "range": [
+      101,
+      104
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "c",
+    "range": [
+      105,
+      106
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 4
+      },
+      "end": {
+        "line": 6,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      107,
+      108
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 6
+      },
+      "end": {
+        "line": 6,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      109,
+      110
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 8
+      },
+      "end": {
+        "line": 6,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      110,
+      111
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 9
+      },
+      "end": {
+        "line": 6,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "c",
+    "range": [
+      112,
+      113
+    ],
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 0
+      },
+      "end": {
+        "line": 7,
+        "column": 1
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "||=",
+    "range": [
+      114,
+      117
+    ],
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 2
+      },
+      "end": {
+        "line": 7,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "3",
+    "range": [
+      118,
+      119
+    ],
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 6
+      },
+      "end": {
+        "line": 7,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      119,
+      120
+    ],
+    "loc": {
+      "start": {
+        "line": 7,
+        "column": 7
+      },
+      "end": {
+        "line": 7,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      122,
+      127
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 0
+      },
+      "end": {
+        "line": 9,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "obj2",
+    "range": [
+      128,
+      132
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 6
+      },
+      "end": {
+        "line": 9,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      133,
+      134
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 11
+      },
+      "end": {
+        "line": 9,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      135,
+      136
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 13
+      },
+      "end": {
+        "line": 9,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      136,
+      137
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 14
+      },
+      "end": {
+        "line": 9,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      137,
+      138
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 15
+      },
+      "end": {
+        "line": 9,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "obj2",
+    "range": [
+      139,
+      143
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 0
+      },
+      "end": {
+        "line": 10,
+        "column": 4
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      143,
+      144
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 4
+      },
+      "end": {
+        "line": 10,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "key",
+    "range": [
+      144,
+      147
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 5
+      },
+      "end": {
+        "line": 10,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "??=",
+    "range": [
+      148,
+      151
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 9
+      },
+      "end": {
+        "line": 10,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'abc'",
+    "range": [
+      152,
+      157
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 13
+      },
+      "end": {
+        "line": 10,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      157,
+      158
+    ],
+    "loc": {
+      "start": {
+        "line": 10,
+        "column": 18
+      },
+      "end": {
+        "line": 10,
+        "column": 19
+      }
+    }
+  }
+]

--- a/tests/fixtures/test-0386.js
+++ b/tests/fixtures/test-0386.js
@@ -1,0 +1,10 @@
+const obj = { s: '', n: 0, a: null };
+obj.s ||= 'default value';
+obj.n &&= obj.n * 2;
+obj.a ??= [];
+
+let c = 0;
+c ||= 3;
+
+const obj2 = {};
+obj2.key ??= 'abc';

--- a/tests/fixtures/test-0387-parse-expected.json
+++ b/tests/fixtures/test-0387-parse-expected.json
@@ -1,0 +1,2212 @@
+{
+  "range": [
+    0,
+    377
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 20,
+      "column": 32
+    }
+  },
+  "type": "Program",
+  "body": [
+    {
+      "range": [
+        0,
+        28
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 28
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            4,
+            12
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 4
+            },
+            "end": {
+              "line": 1,
+              "column": 12
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              4,
+              5
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 5
+              }
+            },
+            "type": "Identifier",
+            "name": "a"
+          },
+          "init": {
+            "range": [
+              8,
+              12
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 8
+              },
+              "end": {
+                "line": 1,
+                "column": 12
+              }
+            },
+            "type": "Literal",
+            "value": null,
+            "raw": "null"
+          }
+        },
+        {
+          "range": [
+            14,
+            19
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 1,
+              "column": 19
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              14,
+              15
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 14
+              },
+              "end": {
+                "line": 1,
+                "column": 15
+              }
+            },
+            "type": "Identifier",
+            "name": "b"
+          },
+          "init": {
+            "range": [
+              18,
+              19
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 18
+              },
+              "end": {
+                "line": 1,
+                "column": 19
+              }
+            },
+            "type": "Literal",
+            "value": 0,
+            "raw": "0"
+          }
+        },
+        {
+          "range": [
+            21,
+            27
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 21
+            },
+            "end": {
+              "line": 1,
+              "column": 27
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              21,
+              22
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 21
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            },
+            "type": "Identifier",
+            "name": "c"
+          },
+          "init": {
+            "range": [
+              25,
+              27
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 25
+              },
+              "end": {
+                "line": 1,
+                "column": 27
+              }
+            },
+            "type": "Literal",
+            "value": "",
+            "raw": "''"
+          }
+        }
+      ],
+      "kind": "let"
+    },
+    {
+      "range": [
+        29,
+        55
+      ],
+      "loc": {
+        "start": {
+          "line": 2,
+          "column": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 26
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            35,
+            54
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 6
+            },
+            "end": {
+              "line": 2,
+              "column": 25
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              35,
+              37
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 8
+              }
+            },
+            "type": "Identifier",
+            "name": "r1"
+          },
+          "init": {
+            "range": [
+              40,
+              54
+            ],
+            "loc": {
+              "start": {
+                "line": 2,
+                "column": 11
+              },
+              "end": {
+                "line": 2,
+                "column": 25
+              }
+            },
+            "type": "LogicalExpression",
+            "operator": "&&",
+            "left": {
+              "range": [
+                41,
+                48
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 12
+                },
+                "end": {
+                  "line": 2,
+                  "column": 19
+                }
+              },
+              "type": "AssignmentExpression",
+              "operator": "&&=",
+              "left": {
+                "range": [
+                  41,
+                  42
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 13
+                  }
+                },
+                "type": "Identifier",
+                "name": "a"
+              },
+              "right": {
+                "range": [
+                  47,
+                  48
+                ],
+                "loc": {
+                  "start": {
+                    "line": 2,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 19
+                  }
+                },
+                "type": "Literal",
+                "value": 1,
+                "raw": "1"
+              }
+            },
+            "right": {
+              "range": [
+                53,
+                54
+              ],
+              "loc": {
+                "start": {
+                  "line": 2,
+                  "column": 24
+                },
+                "end": {
+                  "line": 2,
+                  "column": 25
+                }
+              },
+              "type": "Literal",
+              "value": 2,
+              "raw": "2"
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        56,
+        89
+      ],
+      "loc": {
+        "start": {
+          "line": 3,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 33
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            62,
+            88
+          ],
+          "loc": {
+            "start": {
+              "line": 3,
+              "column": 6
+            },
+            "end": {
+              "line": 3,
+              "column": 32
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              62,
+              64
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 6
+              },
+              "end": {
+                "line": 3,
+                "column": 8
+              }
+            },
+            "type": "Identifier",
+            "name": "r2"
+          },
+          "init": {
+            "range": [
+              67,
+              88
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 11
+              },
+              "end": {
+                "line": 3,
+                "column": 32
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "+",
+            "left": {
+              "range": [
+                68,
+                75
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 12
+                },
+                "end": {
+                  "line": 3,
+                  "column": 19
+                }
+              },
+              "type": "AssignmentExpression",
+              "operator": "||=",
+              "left": {
+                "range": [
+                  68,
+                  69
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 13
+                  }
+                },
+                "type": "Identifier",
+                "name": "a"
+              },
+              "right": {
+                "range": [
+                  74,
+                  75
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 19
+                  }
+                },
+                "type": "Literal",
+                "value": 5,
+                "raw": "5"
+              }
+            },
+            "right": {
+              "range": [
+                80,
+                87
+              ],
+              "loc": {
+                "start": {
+                  "line": 3,
+                  "column": 24
+                },
+                "end": {
+                  "line": 3,
+                  "column": 31
+                }
+              },
+              "type": "AssignmentExpression",
+              "operator": "??=",
+              "left": {
+                "range": [
+                  80,
+                  81
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 25
+                  }
+                },
+                "type": "Identifier",
+                "name": "b"
+              },
+              "right": {
+                "range": [
+                  86,
+                  87
+                ],
+                "loc": {
+                  "start": {
+                    "line": 3,
+                    "column": 30
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 31
+                  }
+                },
+                "type": "Literal",
+                "value": 7,
+                "raw": "7"
+              }
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        91,
+        101
+      ],
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 0
+        },
+        "end": {
+          "line": 5,
+          "column": 10
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            95,
+            100
+          ],
+          "loc": {
+            "start": {
+              "line": 5,
+              "column": 4
+            },
+            "end": {
+              "line": 5,
+              "column": 9
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              95,
+              96
+            ],
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 4
+              },
+              "end": {
+                "line": 5,
+                "column": 5
+              }
+            },
+            "type": "Identifier",
+            "name": "x"
+          },
+          "init": {
+            "range": [
+              99,
+              100
+            ],
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 8
+              },
+              "end": {
+                "line": 5,
+                "column": 9
+              }
+            },
+            "type": "Literal",
+            "value": 1,
+            "raw": "1"
+          }
+        }
+      ],
+      "kind": "let"
+    },
+    {
+      "range": [
+        102,
+        142
+      ],
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 0
+        },
+        "end": {
+          "line": 6,
+          "column": 40
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            108,
+            141
+          ],
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 6
+            },
+            "end": {
+              "line": 6,
+              "column": 39
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              108,
+              111
+            ],
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 6
+              },
+              "end": {
+                "line": 6,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "arr"
+          },
+          "init": {
+            "range": [
+              114,
+              141
+            ],
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 12
+              },
+              "end": {
+                "line": 6,
+                "column": 39
+              }
+            },
+            "type": "ArrayExpression",
+            "elements": [
+              {
+                "range": [
+                  115,
+                  122
+                ],
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 20
+                  }
+                },
+                "type": "AssignmentExpression",
+                "operator": "||=",
+                "left": {
+                  "range": [
+                    115,
+                    116
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 14
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "x"
+                },
+                "right": {
+                  "range": [
+                    121,
+                    122
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 19
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 20
+                    }
+                  },
+                  "type": "Literal",
+                  "value": 2,
+                  "raw": "2"
+                }
+              },
+              {
+                "range": [
+                  124,
+                  131
+                ],
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 22
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 29
+                  }
+                },
+                "type": "AssignmentExpression",
+                "operator": "&&=",
+                "left": {
+                  "range": [
+                    124,
+                    125
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 23
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "x"
+                },
+                "right": {
+                  "range": [
+                    130,
+                    131
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 28
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 29
+                    }
+                  },
+                  "type": "Literal",
+                  "value": 3,
+                  "raw": "3"
+                }
+              },
+              {
+                "range": [
+                  133,
+                  140
+                ],
+                "loc": {
+                  "start": {
+                    "line": 6,
+                    "column": 31
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 38
+                  }
+                },
+                "type": "AssignmentExpression",
+                "operator": "??=",
+                "left": {
+                  "range": [
+                    133,
+                    134
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 31
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 32
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "x"
+                },
+                "right": {
+                  "range": [
+                    139,
+                    140
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 6,
+                      "column": 37
+                    },
+                    "end": {
+                      "line": 6,
+                      "column": 38
+                    }
+                  },
+                  "type": "Literal",
+                  "value": 4,
+                  "raw": "4"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        144,
+        165
+      ],
+      "loc": {
+        "start": {
+          "line": 8,
+          "column": 0
+        },
+        "end": {
+          "line": 8,
+          "column": 21
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            150,
+            164
+          ],
+          "loc": {
+            "start": {
+              "line": 8,
+              "column": 6
+            },
+            "end": {
+              "line": 8,
+              "column": 20
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              150,
+              153
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 6
+              },
+              "end": {
+                "line": 8,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "obj"
+          },
+          "init": {
+            "range": [
+              156,
+              164
+            ],
+            "loc": {
+              "start": {
+                "line": 8,
+                "column": 12
+              },
+              "end": {
+                "line": 8,
+                "column": 20
+              }
+            },
+            "type": "ObjectExpression",
+            "properties": [
+              {
+                "range": [
+                  158,
+                  162
+                ],
+                "loc": {
+                  "start": {
+                    "line": 8,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 8,
+                    "column": 18
+                  }
+                },
+                "type": "Property",
+                "key": {
+                  "range": [
+                    158,
+                    159
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 14
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 15
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "p"
+                },
+                "computed": false,
+                "value": {
+                  "range": [
+                    161,
+                    162
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 8,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 8,
+                      "column": 18
+                    }
+                  },
+                  "type": "Literal",
+                  "value": 0,
+                  "raw": "0"
+                },
+                "kind": "init",
+                "method": false,
+                "shorthand": false
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        166,
+        196
+      ],
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 0
+        },
+        "end": {
+          "line": 9,
+          "column": 30
+        }
+      },
+      "type": "ExpressionStatement",
+      "expression": {
+        "range": [
+          166,
+          195
+        ],
+        "loc": {
+          "start": {
+            "line": 9,
+            "column": 0
+          },
+          "end": {
+            "line": 9,
+            "column": 29
+          }
+        },
+        "type": "AssignmentExpression",
+        "operator": "||=",
+        "left": {
+          "range": [
+            166,
+            171
+          ],
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 0
+            },
+            "end": {
+              "line": 9,
+              "column": 5
+            }
+          },
+          "type": "MemberExpression",
+          "computed": false,
+          "optional": false,
+          "object": {
+            "range": [
+              166,
+              169
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 0
+              },
+              "end": {
+                "line": 9,
+                "column": 3
+              }
+            },
+            "type": "Identifier",
+            "name": "obj"
+          },
+          "property": {
+            "range": [
+              170,
+              171
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 4
+              },
+              "end": {
+                "line": 9,
+                "column": 5
+              }
+            },
+            "type": "Identifier",
+            "name": "p"
+          }
+        },
+        "right": {
+          "range": [
+            176,
+            195
+          ],
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 10
+            },
+            "end": {
+              "line": 9,
+              "column": 29
+            }
+          },
+          "type": "ConditionalExpression",
+          "test": {
+            "range": [
+              176,
+              185
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 10
+              },
+              "end": {
+                "line": 9,
+                "column": 19
+              }
+            },
+            "type": "BinaryExpression",
+            "operator": "<",
+            "left": {
+              "range": [
+                176,
+                181
+              ],
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 10
+                },
+                "end": {
+                  "line": 9,
+                  "column": 15
+                }
+              },
+              "type": "MemberExpression",
+              "computed": false,
+              "optional": false,
+              "object": {
+                "range": [
+                  176,
+                  179
+                ],
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 13
+                  }
+                },
+                "type": "Identifier",
+                "name": "obj"
+              },
+              "property": {
+                "range": [
+                  180,
+                  181
+                ],
+                "loc": {
+                  "start": {
+                    "line": 9,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 9,
+                    "column": 15
+                  }
+                },
+                "type": "Identifier",
+                "name": "p"
+              }
+            },
+            "right": {
+              "range": [
+                184,
+                185
+              ],
+              "loc": {
+                "start": {
+                  "line": 9,
+                  "column": 18
+                },
+                "end": {
+                  "line": 9,
+                  "column": 19
+                }
+              },
+              "type": "Literal",
+              "value": 5,
+              "raw": "5"
+            }
+          },
+          "consequent": {
+            "range": [
+              188,
+              190
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 22
+              },
+              "end": {
+                "line": 9,
+                "column": 24
+              }
+            },
+            "type": "Literal",
+            "value": 10,
+            "raw": "10"
+          },
+          "alternate": {
+            "range": [
+              193,
+              195
+            ],
+            "loc": {
+              "start": {
+                "line": 9,
+                "column": 27
+              },
+              "end": {
+                "line": 9,
+                "column": 29
+              }
+            },
+            "type": "Literal",
+            "value": 20,
+            "raw": "20"
+          }
+        }
+      }
+    },
+    {
+      "range": [
+        198,
+        207
+      ],
+      "loc": {
+        "start": {
+          "line": 11,
+          "column": 0
+        },
+        "end": {
+          "line": 11,
+          "column": 9
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            202,
+            203
+          ],
+          "loc": {
+            "start": {
+              "line": 11,
+              "column": 4
+            },
+            "end": {
+              "line": 11,
+              "column": 5
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              202,
+              203
+            ],
+            "loc": {
+              "start": {
+                "line": 11,
+                "column": 4
+              },
+              "end": {
+                "line": 11,
+                "column": 5
+              }
+            },
+            "type": "Identifier",
+            "name": "m"
+          },
+          "init": null
+        },
+        {
+          "range": [
+            205,
+            206
+          ],
+          "loc": {
+            "start": {
+              "line": 11,
+              "column": 7
+            },
+            "end": {
+              "line": 11,
+              "column": 8
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              205,
+              206
+            ],
+            "loc": {
+              "start": {
+                "line": 11,
+                "column": 7
+              },
+              "end": {
+                "line": 11,
+                "column": 8
+              }
+            },
+            "type": "Identifier",
+            "name": "n"
+          },
+          "init": null
+        }
+      ],
+      "kind": "let"
+    },
+    {
+      "range": [
+        208,
+        238
+      ],
+      "loc": {
+        "start": {
+          "line": 12,
+          "column": 0
+        },
+        "end": {
+          "line": 12,
+          "column": 30
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            214,
+            237
+          ],
+          "loc": {
+            "start": {
+              "line": 12,
+              "column": 6
+            },
+            "end": {
+              "line": 12,
+              "column": 29
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              214,
+              219
+            ],
+            "loc": {
+              "start": {
+                "line": 12,
+                "column": 6
+              },
+              "end": {
+                "line": 12,
+                "column": 11
+              }
+            },
+            "type": "Identifier",
+            "name": "chain"
+          },
+          "init": {
+            "range": [
+              222,
+              237
+            ],
+            "loc": {
+              "start": {
+                "line": 12,
+                "column": 14
+              },
+              "end": {
+                "line": 12,
+                "column": 29
+              }
+            },
+            "type": "AssignmentExpression",
+            "operator": "||=",
+            "left": {
+              "range": [
+                222,
+                223
+              ],
+              "loc": {
+                "start": {
+                  "line": 12,
+                  "column": 14
+                },
+                "end": {
+                  "line": 12,
+                  "column": 15
+                }
+              },
+              "type": "Identifier",
+              "name": "m"
+            },
+            "right": {
+              "range": [
+                228,
+                237
+              ],
+              "loc": {
+                "start": {
+                  "line": 12,
+                  "column": 20
+                },
+                "end": {
+                  "line": 12,
+                  "column": 29
+                }
+              },
+              "type": "AssignmentExpression",
+              "operator": "??=",
+              "left": {
+                "range": [
+                  228,
+                  229
+                ],
+                "loc": {
+                  "start": {
+                    "line": 12,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 12,
+                    "column": 21
+                  }
+                },
+                "type": "Identifier",
+                "name": "n"
+              },
+              "right": {
+                "range": [
+                  234,
+                  237
+                ],
+                "loc": {
+                  "start": {
+                    "line": 12,
+                    "column": 26
+                  },
+                  "end": {
+                    "line": 12,
+                    "column": 29
+                  }
+                },
+                "type": "Literal",
+                "value": "z",
+                "raw": "'z'"
+              }
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        240,
+        277
+      ],
+      "loc": {
+        "start": {
+          "line": 14,
+          "column": 0
+        },
+        "end": {
+          "line": 14,
+          "column": 37
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            246,
+            276
+          ],
+          "loc": {
+            "start": {
+              "line": 14,
+              "column": 6
+            },
+            "end": {
+              "line": 14,
+              "column": 36
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              246,
+              252
+            ],
+            "loc": {
+              "start": {
+                "line": 14,
+                "column": 6
+              },
+              "end": {
+                "line": 14,
+                "column": 12
+              }
+            },
+            "type": "Identifier",
+            "name": "dynKey"
+          },
+          "init": {
+            "range": [
+              255,
+              276
+            ],
+            "loc": {
+              "start": {
+                "line": 14,
+                "column": 15
+              },
+              "end": {
+                "line": 14,
+                "column": 36
+              }
+            },
+            "type": "MemberExpression",
+            "computed": true,
+            "optional": false,
+            "object": {
+              "range": [
+                256,
+                264
+              ],
+              "loc": {
+                "start": {
+                  "line": 14,
+                  "column": 16
+                },
+                "end": {
+                  "line": 14,
+                  "column": 24
+                }
+              },
+              "type": "ObjectExpression",
+              "properties": [
+                {
+                  "range": [
+                    258,
+                    262
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 14,
+                      "column": 18
+                    },
+                    "end": {
+                      "line": 14,
+                      "column": 22
+                    }
+                  },
+                  "type": "Property",
+                  "key": {
+                    "range": [
+                      258,
+                      259
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 14,
+                        "column": 18
+                      },
+                      "end": {
+                        "line": 14,
+                        "column": 19
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "y"
+                  },
+                  "computed": false,
+                  "value": {
+                    "range": [
+                      261,
+                      262
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 14,
+                        "column": 21
+                      },
+                      "end": {
+                        "line": 14,
+                        "column": 22
+                      }
+                    },
+                    "type": "Literal",
+                    "value": 1,
+                    "raw": "1"
+                  },
+                  "kind": "init",
+                  "method": false,
+                  "shorthand": false
+                }
+              ]
+            },
+            "property": {
+              "range": [
+                266,
+                275
+              ],
+              "loc": {
+                "start": {
+                  "line": 14,
+                  "column": 26
+                },
+                "end": {
+                  "line": 14,
+                  "column": 35
+                }
+              },
+              "type": "AssignmentExpression",
+              "operator": "||=",
+              "left": {
+                "range": [
+                  266,
+                  267
+                ],
+                "loc": {
+                  "start": {
+                    "line": 14,
+                    "column": 26
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 27
+                  }
+                },
+                "type": "Identifier",
+                "name": "c"
+              },
+              "right": {
+                "range": [
+                  272,
+                  275
+                ],
+                "loc": {
+                  "start": {
+                    "line": 14,
+                    "column": 32
+                  },
+                  "end": {
+                    "line": 14,
+                    "column": 35
+                  }
+                },
+                "type": "Literal",
+                "value": "y",
+                "raw": "'y'"
+              }
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        279,
+        314
+      ],
+      "loc": {
+        "start": {
+          "line": 16,
+          "column": 0
+        },
+        "end": {
+          "line": 16,
+          "column": 35
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            285,
+            313
+          ],
+          "loc": {
+            "start": {
+              "line": 16,
+              "column": 6
+            },
+            "end": {
+              "line": 16,
+              "column": 34
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              285,
+              288
+            ],
+            "loc": {
+              "start": {
+                "line": 16,
+                "column": 6
+              },
+              "end": {
+                "line": 16,
+                "column": 9
+              }
+            },
+            "type": "Identifier",
+            "name": "seq"
+          },
+          "init": {
+            "range": [
+              292,
+              312
+            ],
+            "loc": {
+              "start": {
+                "line": 16,
+                "column": 13
+              },
+              "end": {
+                "line": 16,
+                "column": 33
+              }
+            },
+            "type": "SequenceExpression",
+            "expressions": [
+              {
+                "range": [
+                  292,
+                  303
+                ],
+                "loc": {
+                  "start": {
+                    "line": 16,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 16,
+                    "column": 24
+                  }
+                },
+                "type": "AssignmentExpression",
+                "operator": "&&=",
+                "left": {
+                  "range": [
+                    292,
+                    293
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 16,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 16,
+                      "column": 14
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "a"
+                },
+                "right": {
+                  "range": [
+                    298,
+                    303
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 16,
+                      "column": 19
+                    },
+                    "end": {
+                      "line": 16,
+                      "column": 24
+                    }
+                  },
+                  "type": "BinaryExpression",
+                  "operator": "+",
+                  "left": {
+                    "range": [
+                      298,
+                      299
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 16,
+                        "column": 19
+                      },
+                      "end": {
+                        "line": 16,
+                        "column": 20
+                      }
+                    },
+                    "type": "Identifier",
+                    "name": "a"
+                  },
+                  "right": {
+                    "range": [
+                      302,
+                      303
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 16,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 16,
+                        "column": 24
+                      }
+                    },
+                    "type": "Literal",
+                    "value": 1,
+                    "raw": "1"
+                  }
+                }
+              },
+              {
+                "range": [
+                  305,
+                  312
+                ],
+                "loc": {
+                  "start": {
+                    "line": 16,
+                    "column": 26
+                  },
+                  "end": {
+                    "line": 16,
+                    "column": 33
+                  }
+                },
+                "type": "AssignmentExpression",
+                "operator": "??=",
+                "left": {
+                  "range": [
+                    305,
+                    306
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 16,
+                      "column": 26
+                    },
+                    "end": {
+                      "line": 16,
+                      "column": 27
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "b"
+                },
+                "right": {
+                  "range": [
+                    311,
+                    312
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 16,
+                      "column": 32
+                    },
+                    "end": {
+                      "line": 16,
+                      "column": 33
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "b"
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        316,
+        343
+      ],
+      "loc": {
+        "start": {
+          "line": 18,
+          "column": 0
+        },
+        "end": {
+          "line": 18,
+          "column": 27
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            322,
+            342
+          ],
+          "loc": {
+            "start": {
+              "line": 18,
+              "column": 6
+            },
+            "end": {
+              "line": 18,
+              "column": 26
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              322,
+              324
+            ],
+            "loc": {
+              "start": {
+                "line": 18,
+                "column": 6
+              },
+              "end": {
+                "line": 18,
+                "column": 8
+              }
+            },
+            "type": "Identifier",
+            "name": "eq"
+          },
+          "init": {
+            "range": [
+              328,
+              341
+            ],
+            "loc": {
+              "start": {
+                "line": 18,
+                "column": 12
+              },
+              "end": {
+                "line": 18,
+                "column": 25
+              }
+            },
+            "type": "AssignmentExpression",
+            "operator": "&&=",
+            "left": {
+              "range": [
+                328,
+                329
+              ],
+              "loc": {
+                "start": {
+                  "line": 18,
+                  "column": 12
+                },
+                "end": {
+                  "line": 18,
+                  "column": 13
+                }
+              },
+              "type": "Identifier",
+              "name": "b"
+            },
+            "right": {
+              "range": [
+                334,
+                341
+              ],
+              "loc": {
+                "start": {
+                  "line": 18,
+                  "column": 18
+                },
+                "end": {
+                  "line": 18,
+                  "column": 25
+                }
+              },
+              "type": "BinaryExpression",
+              "operator": "===",
+              "left": {
+                "range": [
+                  334,
+                  335
+                ],
+                "loc": {
+                  "start": {
+                    "line": 18,
+                    "column": 18
+                  },
+                  "end": {
+                    "line": 18,
+                    "column": 19
+                  }
+                },
+                "type": "Identifier",
+                "name": "b"
+              },
+              "right": {
+                "range": [
+                  340,
+                  341
+                ],
+                "loc": {
+                  "start": {
+                    "line": 18,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 18,
+                    "column": 25
+                  }
+                },
+                "type": "Literal",
+                "value": 0,
+                "raw": "0"
+              }
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    },
+    {
+      "range": [
+        345,
+        377
+      ],
+      "loc": {
+        "start": {
+          "line": 20,
+          "column": 0
+        },
+        "end": {
+          "line": 20,
+          "column": 32
+        }
+      },
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "range": [
+            351,
+            376
+          ],
+          "loc": {
+            "start": {
+              "line": 20,
+              "column": 6
+            },
+            "end": {
+              "line": 20,
+              "column": 31
+            }
+          },
+          "type": "VariableDeclarator",
+          "id": {
+            "range": [
+              351,
+              353
+            ],
+            "loc": {
+              "start": {
+                "line": 20,
+                "column": 6
+              },
+              "end": {
+                "line": 20,
+                "column": 8
+              }
+            },
+            "type": "Identifier",
+            "name": "re"
+          },
+          "init": {
+            "range": [
+              356,
+              376
+            ],
+            "loc": {
+              "start": {
+                "line": 20,
+                "column": 11
+              },
+              "end": {
+                "line": 20,
+                "column": 31
+              }
+            },
+            "type": "AssignmentExpression",
+            "operator": "||=",
+            "left": {
+              "range": [
+                356,
+                357
+              ],
+              "loc": {
+                "start": {
+                  "line": 20,
+                  "column": 11
+                },
+                "end": {
+                  "line": 20,
+                  "column": 12
+                }
+              },
+              "type": "Identifier",
+              "name": "a"
+            },
+            "right": {
+              "range": [
+                362,
+                376
+              ],
+              "loc": {
+                "start": {
+                  "line": 20,
+                  "column": 17
+                },
+                "end": {
+                  "line": 20,
+                  "column": 31
+                }
+              },
+              "type": "CallExpression",
+              "callee": {
+                "range": [
+                  362,
+                  371
+                ],
+                "loc": {
+                  "start": {
+                    "line": 20,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 20,
+                    "column": 26
+                  }
+                },
+                "type": "MemberExpression",
+                "computed": false,
+                "optional": false,
+                "object": {
+                  "range": [
+                    362,
+                    366
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 20,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 20,
+                      "column": 21
+                    }
+                  },
+                  "type": "Literal",
+                  "value": {},
+                  "raw": "/^x/",
+                  "regex": {
+                    "pattern": "^x",
+                    "flags": ""
+                  }
+                },
+                "property": {
+                  "range": [
+                    367,
+                    371
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 20,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 20,
+                      "column": 26
+                    }
+                  },
+                  "type": "Identifier",
+                  "name": "test"
+                }
+              },
+              "optional": false,
+              "arguments": [
+                {
+                  "range": [
+                    372,
+                    375
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 20,
+                      "column": 27
+                    },
+                    "end": {
+                      "line": 20,
+                      "column": 30
+                    }
+                  },
+                  "type": "Literal",
+                  "value": "x",
+                  "raw": "'x'"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "kind": "const"
+    }
+  ]
+}

--- a/tests/fixtures/test-0387-tokenize-expected.json
+++ b/tests/fixtures/test-0387-tokenize-expected.json
@@ -1,0 +1,614 @@
+[
+  {
+    "type": "Keyword",
+    "value": "let"
+  },
+  {
+    "type": "Identifier",
+    "value": "a"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Null",
+    "value": "null"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "b"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "c"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "String",
+    "value": "''"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "r1"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "a"
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&="
+  },
+  {
+    "type": "Numeric",
+    "value": "1"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&"
+  },
+  {
+    "type": "Numeric",
+    "value": "2"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "r2"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "a"
+  },
+  {
+    "type": "Punctuator",
+    "value": "||="
+  },
+  {
+    "type": "Numeric",
+    "value": "5"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "+"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "b"
+  },
+  {
+    "type": "Punctuator",
+    "value": "??="
+  },
+  {
+    "type": "Numeric",
+    "value": "7"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "let"
+  },
+  {
+    "type": "Identifier",
+    "value": "x"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Numeric",
+    "value": "1"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "arr"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "["
+  },
+  {
+    "type": "Identifier",
+    "value": "x"
+  },
+  {
+    "type": "Punctuator",
+    "value": "||="
+  },
+  {
+    "type": "Numeric",
+    "value": "2"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "x"
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&="
+  },
+  {
+    "type": "Numeric",
+    "value": "3"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "x"
+  },
+  {
+    "type": "Punctuator",
+    "value": "??="
+  },
+  {
+    "type": "Numeric",
+    "value": "4"
+  },
+  {
+    "type": "Punctuator",
+    "value": "]"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "obj"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "p"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Identifier",
+    "value": "obj"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "p"
+  },
+  {
+    "type": "Punctuator",
+    "value": "||="
+  },
+  {
+    "type": "Identifier",
+    "value": "obj"
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "p"
+  },
+  {
+    "type": "Punctuator",
+    "value": "<"
+  },
+  {
+    "type": "Numeric",
+    "value": "5"
+  },
+  {
+    "type": "Punctuator",
+    "value": "?"
+  },
+  {
+    "type": "Numeric",
+    "value": "10"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "Numeric",
+    "value": "20"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "let"
+  },
+  {
+    "type": "Identifier",
+    "value": "m"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "chain"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "m"
+  },
+  {
+    "type": "Punctuator",
+    "value": "||="
+  },
+  {
+    "type": "Identifier",
+    "value": "n"
+  },
+  {
+    "type": "Punctuator",
+    "value": "??="
+  },
+  {
+    "type": "String",
+    "value": "'z'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "dynKey"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Punctuator",
+    "value": "{"
+  },
+  {
+    "type": "Identifier",
+    "value": "y"
+  },
+  {
+    "type": "Punctuator",
+    "value": ":"
+  },
+  {
+    "type": "Numeric",
+    "value": "1"
+  },
+  {
+    "type": "Punctuator",
+    "value": "}"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": "["
+  },
+  {
+    "type": "Identifier",
+    "value": "c"
+  },
+  {
+    "type": "Punctuator",
+    "value": "||="
+  },
+  {
+    "type": "String",
+    "value": "'y'"
+  },
+  {
+    "type": "Punctuator",
+    "value": "]"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "seq"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "a"
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&="
+  },
+  {
+    "type": "Identifier",
+    "value": "a"
+  },
+  {
+    "type": "Punctuator",
+    "value": "+"
+  },
+  {
+    "type": "Numeric",
+    "value": "1"
+  },
+  {
+    "type": "Punctuator",
+    "value": ","
+  },
+  {
+    "type": "Identifier",
+    "value": "b"
+  },
+  {
+    "type": "Punctuator",
+    "value": "??="
+  },
+  {
+    "type": "Identifier",
+    "value": "b"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "eq"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "Identifier",
+    "value": "b"
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&="
+  },
+  {
+    "type": "Identifier",
+    "value": "b"
+  },
+  {
+    "type": "Punctuator",
+    "value": "==="
+  },
+  {
+    "type": "Numeric",
+    "value": "0"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  },
+  {
+    "type": "Keyword",
+    "value": "const"
+  },
+  {
+    "type": "Identifier",
+    "value": "re"
+  },
+  {
+    "type": "Punctuator",
+    "value": "="
+  },
+  {
+    "type": "Identifier",
+    "value": "a"
+  },
+  {
+    "type": "Punctuator",
+    "value": "||="
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/^x/",
+    "regex": {
+      "pattern": "^x",
+      "flags": ""
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "."
+  },
+  {
+    "type": "Identifier",
+    "value": "test"
+  },
+  {
+    "type": "Punctuator",
+    "value": "("
+  },
+  {
+    "type": "String",
+    "value": "'x'"
+  },
+  {
+    "type": "Punctuator",
+    "value": ")"
+  },
+  {
+    "type": "Punctuator",
+    "value": ";"
+  }
+]

--- a/tests/fixtures/test-0387-tokenize-loc-range-expected.json
+++ b/tests/fixtures/test-0387-tokenize-loc-range-expected.json
@@ -1,0 +1,2742 @@
+[
+  {
+    "type": "Keyword",
+    "value": "let",
+    "range": [
+      0,
+      3
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "a",
+    "range": [
+      4,
+      5
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 4
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      6,
+      7
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Null",
+    "value": "null",
+    "range": [
+      8,
+      12
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 8
+      },
+      "end": {
+        "line": 1,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      12,
+      13
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 12
+      },
+      "end": {
+        "line": 1,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "b",
+    "range": [
+      14,
+      15
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 14
+      },
+      "end": {
+        "line": 1,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      16,
+      17
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 16
+      },
+      "end": {
+        "line": 1,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      18,
+      19
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 18
+      },
+      "end": {
+        "line": 1,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      19,
+      20
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 19
+      },
+      "end": {
+        "line": 1,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "c",
+    "range": [
+      21,
+      22
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 21
+      },
+      "end": {
+        "line": 1,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      23,
+      24
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 23
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "''",
+    "range": [
+      25,
+      27
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 25
+      },
+      "end": {
+        "line": 1,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      27,
+      28
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 27
+      },
+      "end": {
+        "line": 1,
+        "column": 28
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      29,
+      34
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 0
+      },
+      "end": {
+        "line": 2,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "r1",
+    "range": [
+      35,
+      37
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 6
+      },
+      "end": {
+        "line": 2,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      38,
+      39
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 9
+      },
+      "end": {
+        "line": 2,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      40,
+      41
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 11
+      },
+      "end": {
+        "line": 2,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "a",
+    "range": [
+      41,
+      42
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 12
+      },
+      "end": {
+        "line": 2,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&=",
+    "range": [
+      43,
+      46
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 14
+      },
+      "end": {
+        "line": 2,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "1",
+    "range": [
+      47,
+      48
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 18
+      },
+      "end": {
+        "line": 2,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      48,
+      49
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 19
+      },
+      "end": {
+        "line": 2,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&",
+    "range": [
+      50,
+      52
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 21
+      },
+      "end": {
+        "line": 2,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "2",
+    "range": [
+      53,
+      54
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 24
+      },
+      "end": {
+        "line": 2,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      54,
+      55
+    ],
+    "loc": {
+      "start": {
+        "line": 2,
+        "column": 25
+      },
+      "end": {
+        "line": 2,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      56,
+      61
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "r2",
+    "range": [
+      62,
+      64
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 6
+      },
+      "end": {
+        "line": 3,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      65,
+      66
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 9
+      },
+      "end": {
+        "line": 3,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      67,
+      68
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 11
+      },
+      "end": {
+        "line": 3,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "a",
+    "range": [
+      68,
+      69
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 12
+      },
+      "end": {
+        "line": 3,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "||=",
+    "range": [
+      70,
+      73
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 14
+      },
+      "end": {
+        "line": 3,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "5",
+    "range": [
+      74,
+      75
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 18
+      },
+      "end": {
+        "line": 3,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      75,
+      76
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 19
+      },
+      "end": {
+        "line": 3,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "+",
+    "range": [
+      77,
+      78
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 21
+      },
+      "end": {
+        "line": 3,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      79,
+      80
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 23
+      },
+      "end": {
+        "line": 3,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "b",
+    "range": [
+      80,
+      81
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 24
+      },
+      "end": {
+        "line": 3,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "??=",
+    "range": [
+      82,
+      85
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 26
+      },
+      "end": {
+        "line": 3,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "7",
+    "range": [
+      86,
+      87
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 30
+      },
+      "end": {
+        "line": 3,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      87,
+      88
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 31
+      },
+      "end": {
+        "line": 3,
+        "column": 32
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      88,
+      89
+    ],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 32
+      },
+      "end": {
+        "line": 3,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "let",
+    "range": [
+      91,
+      94
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "x",
+    "range": [
+      95,
+      96
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 4
+      },
+      "end": {
+        "line": 5,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      97,
+      98
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 6
+      },
+      "end": {
+        "line": 5,
+        "column": 7
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "1",
+    "range": [
+      99,
+      100
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 8
+      },
+      "end": {
+        "line": 5,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      100,
+      101
+    ],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 9
+      },
+      "end": {
+        "line": 5,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      102,
+      107
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 0
+      },
+      "end": {
+        "line": 6,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "arr",
+    "range": [
+      108,
+      111
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 6
+      },
+      "end": {
+        "line": 6,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      112,
+      113
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 10
+      },
+      "end": {
+        "line": 6,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "[",
+    "range": [
+      114,
+      115
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 12
+      },
+      "end": {
+        "line": 6,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "x",
+    "range": [
+      115,
+      116
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 13
+      },
+      "end": {
+        "line": 6,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "||=",
+    "range": [
+      117,
+      120
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 15
+      },
+      "end": {
+        "line": 6,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "2",
+    "range": [
+      121,
+      122
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 19
+      },
+      "end": {
+        "line": 6,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      122,
+      123
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 20
+      },
+      "end": {
+        "line": 6,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "x",
+    "range": [
+      124,
+      125
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 22
+      },
+      "end": {
+        "line": 6,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&=",
+    "range": [
+      126,
+      129
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 24
+      },
+      "end": {
+        "line": 6,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "3",
+    "range": [
+      130,
+      131
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 28
+      },
+      "end": {
+        "line": 6,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      131,
+      132
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 29
+      },
+      "end": {
+        "line": 6,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "x",
+    "range": [
+      133,
+      134
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 31
+      },
+      "end": {
+        "line": 6,
+        "column": 32
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "??=",
+    "range": [
+      135,
+      138
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 33
+      },
+      "end": {
+        "line": 6,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "4",
+    "range": [
+      139,
+      140
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 37
+      },
+      "end": {
+        "line": 6,
+        "column": 38
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]",
+    "range": [
+      140,
+      141
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 38
+      },
+      "end": {
+        "line": 6,
+        "column": 39
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      141,
+      142
+    ],
+    "loc": {
+      "start": {
+        "line": 6,
+        "column": 39
+      },
+      "end": {
+        "line": 6,
+        "column": 40
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      144,
+      149
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 0
+      },
+      "end": {
+        "line": 8,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "obj",
+    "range": [
+      150,
+      153
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 6
+      },
+      "end": {
+        "line": 8,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      154,
+      155
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 10
+      },
+      "end": {
+        "line": 8,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      156,
+      157
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 12
+      },
+      "end": {
+        "line": 8,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "p",
+    "range": [
+      158,
+      159
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 14
+      },
+      "end": {
+        "line": 8,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      159,
+      160
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 15
+      },
+      "end": {
+        "line": 8,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      161,
+      162
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 17
+      },
+      "end": {
+        "line": 8,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      163,
+      164
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 19
+      },
+      "end": {
+        "line": 8,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      164,
+      165
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 20
+      },
+      "end": {
+        "line": 8,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "obj",
+    "range": [
+      166,
+      169
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 0
+      },
+      "end": {
+        "line": 9,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      169,
+      170
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 3
+      },
+      "end": {
+        "line": 9,
+        "column": 4
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "p",
+    "range": [
+      170,
+      171
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 4
+      },
+      "end": {
+        "line": 9,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "||=",
+    "range": [
+      172,
+      175
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 6
+      },
+      "end": {
+        "line": 9,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "obj",
+    "range": [
+      176,
+      179
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 10
+      },
+      "end": {
+        "line": 9,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      179,
+      180
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 13
+      },
+      "end": {
+        "line": 9,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "p",
+    "range": [
+      180,
+      181
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 14
+      },
+      "end": {
+        "line": 9,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "<",
+    "range": [
+      182,
+      183
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 16
+      },
+      "end": {
+        "line": 9,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "5",
+    "range": [
+      184,
+      185
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 18
+      },
+      "end": {
+        "line": 9,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "?",
+    "range": [
+      186,
+      187
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 20
+      },
+      "end": {
+        "line": 9,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "10",
+    "range": [
+      188,
+      190
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 22
+      },
+      "end": {
+        "line": 9,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      191,
+      192
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 25
+      },
+      "end": {
+        "line": 9,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "20",
+    "range": [
+      193,
+      195
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 27
+      },
+      "end": {
+        "line": 9,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      195,
+      196
+    ],
+    "loc": {
+      "start": {
+        "line": 9,
+        "column": 29
+      },
+      "end": {
+        "line": 9,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "let",
+    "range": [
+      198,
+      201
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 0
+      },
+      "end": {
+        "line": 11,
+        "column": 3
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "m",
+    "range": [
+      202,
+      203
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 4
+      },
+      "end": {
+        "line": 11,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      203,
+      204
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 5
+      },
+      "end": {
+        "line": 11,
+        "column": 6
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      205,
+      206
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 7
+      },
+      "end": {
+        "line": 11,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      206,
+      207
+    ],
+    "loc": {
+      "start": {
+        "line": 11,
+        "column": 8
+      },
+      "end": {
+        "line": 11,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      208,
+      213
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 0
+      },
+      "end": {
+        "line": 12,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "chain",
+    "range": [
+      214,
+      219
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 6
+      },
+      "end": {
+        "line": 12,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      220,
+      221
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 12
+      },
+      "end": {
+        "line": 12,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "m",
+    "range": [
+      222,
+      223
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 14
+      },
+      "end": {
+        "line": 12,
+        "column": 15
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "||=",
+    "range": [
+      224,
+      227
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 16
+      },
+      "end": {
+        "line": 12,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "n",
+    "range": [
+      228,
+      229
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 20
+      },
+      "end": {
+        "line": 12,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "??=",
+    "range": [
+      230,
+      233
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 22
+      },
+      "end": {
+        "line": 12,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'z'",
+    "range": [
+      234,
+      237
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 26
+      },
+      "end": {
+        "line": 12,
+        "column": 29
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      237,
+      238
+    ],
+    "loc": {
+      "start": {
+        "line": 12,
+        "column": 29
+      },
+      "end": {
+        "line": 12,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      240,
+      245
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 0
+      },
+      "end": {
+        "line": 14,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "dynKey",
+    "range": [
+      246,
+      252
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 6
+      },
+      "end": {
+        "line": 14,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      253,
+      254
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 13
+      },
+      "end": {
+        "line": 14,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      255,
+      256
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 15
+      },
+      "end": {
+        "line": 14,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "{",
+    "range": [
+      256,
+      257
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 16
+      },
+      "end": {
+        "line": 14,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "y",
+    "range": [
+      258,
+      259
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 18
+      },
+      "end": {
+        "line": 14,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ":",
+    "range": [
+      259,
+      260
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 19
+      },
+      "end": {
+        "line": 14,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "1",
+    "range": [
+      261,
+      262
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 21
+      },
+      "end": {
+        "line": 14,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "}",
+    "range": [
+      263,
+      264
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 23
+      },
+      "end": {
+        "line": 14,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      264,
+      265
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 24
+      },
+      "end": {
+        "line": 14,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "[",
+    "range": [
+      265,
+      266
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 25
+      },
+      "end": {
+        "line": 14,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "c",
+    "range": [
+      266,
+      267
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 26
+      },
+      "end": {
+        "line": 14,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "||=",
+    "range": [
+      268,
+      271
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 28
+      },
+      "end": {
+        "line": 14,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'y'",
+    "range": [
+      272,
+      275
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 32
+      },
+      "end": {
+        "line": 14,
+        "column": 35
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "]",
+    "range": [
+      275,
+      276
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 35
+      },
+      "end": {
+        "line": 14,
+        "column": 36
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      276,
+      277
+    ],
+    "loc": {
+      "start": {
+        "line": 14,
+        "column": 36
+      },
+      "end": {
+        "line": 14,
+        "column": 37
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      279,
+      284
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 0
+      },
+      "end": {
+        "line": 16,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "seq",
+    "range": [
+      285,
+      288
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 6
+      },
+      "end": {
+        "line": 16,
+        "column": 9
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      289,
+      290
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 10
+      },
+      "end": {
+        "line": 16,
+        "column": 11
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      291,
+      292
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 12
+      },
+      "end": {
+        "line": 16,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "a",
+    "range": [
+      292,
+      293
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 13
+      },
+      "end": {
+        "line": 16,
+        "column": 14
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&=",
+    "range": [
+      294,
+      297
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 15
+      },
+      "end": {
+        "line": 16,
+        "column": 18
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "a",
+    "range": [
+      298,
+      299
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 19
+      },
+      "end": {
+        "line": 16,
+        "column": 20
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "+",
+    "range": [
+      300,
+      301
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 21
+      },
+      "end": {
+        "line": 16,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "1",
+    "range": [
+      302,
+      303
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 23
+      },
+      "end": {
+        "line": 16,
+        "column": 24
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ",",
+    "range": [
+      303,
+      304
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 24
+      },
+      "end": {
+        "line": 16,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "b",
+    "range": [
+      305,
+      306
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 26
+      },
+      "end": {
+        "line": 16,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "??=",
+    "range": [
+      307,
+      310
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 28
+      },
+      "end": {
+        "line": 16,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "b",
+    "range": [
+      311,
+      312
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 32
+      },
+      "end": {
+        "line": 16,
+        "column": 33
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      312,
+      313
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 33
+      },
+      "end": {
+        "line": 16,
+        "column": 34
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      313,
+      314
+    ],
+    "loc": {
+      "start": {
+        "line": 16,
+        "column": 34
+      },
+      "end": {
+        "line": 16,
+        "column": 35
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      316,
+      321
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 0
+      },
+      "end": {
+        "line": 18,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "eq",
+    "range": [
+      322,
+      324
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 6
+      },
+      "end": {
+        "line": 18,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      325,
+      326
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 9
+      },
+      "end": {
+        "line": 18,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      327,
+      328
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 11
+      },
+      "end": {
+        "line": 18,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "b",
+    "range": [
+      328,
+      329
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 12
+      },
+      "end": {
+        "line": 18,
+        "column": 13
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "&&=",
+    "range": [
+      330,
+      333
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 14
+      },
+      "end": {
+        "line": 18,
+        "column": 17
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "b",
+    "range": [
+      334,
+      335
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 18
+      },
+      "end": {
+        "line": 18,
+        "column": 19
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "===",
+    "range": [
+      336,
+      339
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 20
+      },
+      "end": {
+        "line": 18,
+        "column": 23
+      }
+    }
+  },
+  {
+    "type": "Numeric",
+    "value": "0",
+    "range": [
+      340,
+      341
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 24
+      },
+      "end": {
+        "line": 18,
+        "column": 25
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      341,
+      342
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 25
+      },
+      "end": {
+        "line": 18,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      342,
+      343
+    ],
+    "loc": {
+      "start": {
+        "line": 18,
+        "column": 26
+      },
+      "end": {
+        "line": 18,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "Keyword",
+    "value": "const",
+    "range": [
+      345,
+      350
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 0
+      },
+      "end": {
+        "line": 20,
+        "column": 5
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "re",
+    "range": [
+      351,
+      353
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 6
+      },
+      "end": {
+        "line": 20,
+        "column": 8
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "=",
+    "range": [
+      354,
+      355
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 9
+      },
+      "end": {
+        "line": 20,
+        "column": 10
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "a",
+    "range": [
+      356,
+      357
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 11
+      },
+      "end": {
+        "line": 20,
+        "column": 12
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "||=",
+    "range": [
+      358,
+      361
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 13
+      },
+      "end": {
+        "line": 20,
+        "column": 16
+      }
+    }
+  },
+  {
+    "type": "RegularExpression",
+    "value": "/^x/",
+    "regex": {
+      "pattern": "^x",
+      "flags": ""
+    },
+    "range": [
+      362,
+      366
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 17
+      },
+      "end": {
+        "line": 20,
+        "column": 21
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ".",
+    "range": [
+      366,
+      367
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 21
+      },
+      "end": {
+        "line": 20,
+        "column": 22
+      }
+    }
+  },
+  {
+    "type": "Identifier",
+    "value": "test",
+    "range": [
+      367,
+      371
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 22
+      },
+      "end": {
+        "line": 20,
+        "column": 26
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": "(",
+    "range": [
+      371,
+      372
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 26
+      },
+      "end": {
+        "line": 20,
+        "column": 27
+      }
+    }
+  },
+  {
+    "type": "String",
+    "value": "'x'",
+    "range": [
+      372,
+      375
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 27
+      },
+      "end": {
+        "line": 20,
+        "column": 30
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ")",
+    "range": [
+      375,
+      376
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 30
+      },
+      "end": {
+        "line": 20,
+        "column": 31
+      }
+    }
+  },
+  {
+    "type": "Punctuator",
+    "value": ";",
+    "range": [
+      376,
+      377
+    ],
+    "loc": {
+      "start": {
+        "line": 20,
+        "column": 31
+      },
+      "end": {
+        "line": 20,
+        "column": 32
+      }
+    }
+  }
+]

--- a/tests/fixtures/test-0387.js
+++ b/tests/fixtures/test-0387.js
@@ -1,0 +1,20 @@
+let a = null, b = 0, c = '';
+const r1 = (a &&= 1) && 2;
+const r2 = (a ||= 5) + (b ??= 7);
+
+let x = 1;
+const arr = [x ||= 2, x &&= 3, x ??= 4];
+
+const obj = { p: 0 };
+obj.p ||= obj.p < 5 ? 10 : 20;
+
+let m, n;
+const chain = m ||= n ??= 'z';
+
+const dynKey = ({ y: 1 })[c ||= 'y'];
+
+const seq = (a &&= a + 1, b ??= b);
+
+const eq = (b &&= b === 0);
+
+const re = a ||= /^x/.test('x');

--- a/tests/test.js
+++ b/tests/test.js
@@ -532,6 +532,20 @@ function normalizeEsprimaAst(ast) {
         delete node.generator;
         if (!node.async) delete node.async;
       }
+    },
+    {
+      // Always add `optional: false` because Chiffon always sets it (ESTree spec),
+      // but Esprima 4.0.1 predates optional chaining and never emits it.
+      type: 'CallExpression',
+      callback: (node) => {
+        node.optional = false;
+      }
+    },
+    {
+      type: 'MemberExpression',
+      callback: (node) => {
+        node.optional = false;
+      }
     }
   ]);
   return ast;


### PR DESCRIPTION
## Added

- Optional catch binding (`try {} catch {}` with no parameter)
- JSON superset: allow raw U+2028 / U+2029 in string literals
- Optional chaining `?.`
- Nullish coalescing `??` (`CoalesceExpression`)
- Dynamic `import()`
- `export * as foo from '...'` (`ExportAllDeclaration`)
- BigInt literals (`123n`)
- Numeric separators (`1_000`)
- Logical assignment operators `||=`, `&&=`, `??=`
- RegExp `d` (hasIndices) and `v` (unicodeSets) flags

## Fixed

- Always include `optional`, `options`, and `exported` fields on nodes
- Treat `/` after postfix `++` / `--` as division, not a regex literal
